### PR TITLE
ENH Add User-Level Filtering

### DIFF
--- a/app.R
+++ b/app.R
@@ -19,6 +19,7 @@ pacman::p_load(
 # install.packages("scales")
 
 library(civis)
+library(mdiver)
 # library(bslib)
 library(scales)
 

--- a/app.R
+++ b/app.R
@@ -8,12 +8,14 @@
 
 require(devtools)
 
-# 
+#
 if (!require("pacman")) install.packages("pacman")
 
-pacman::p_load(plyr, tidyverse, ggplot2, leaflet, plotly, 
-               shiny, shinyjs, shinythemes, shinyWidgets, shinyBS, shinybusy,
-               shinydashboard, shinycssloaders)
+pacman::p_load(
+  plyr, tidyverse, ggplot2, leaflet, plotly,
+  shiny, shinyjs, shinythemes, shinyWidgets, shinyBS, shinybusy,
+  shinydashboard, shinycssloaders
+)
 # install.packages("scales")
 
 library(civis)

--- a/app.R
+++ b/app.R
@@ -7,7 +7,6 @@
 # install_version("bslib", version = "0.3.1", repos = "http://cran.us.r-project.org")
 
 require(devtools)
-install_version("scales", version = "1.2.0", repos = "http://cran.us.r-project.org")
 
 # 
 if (!require("pacman")) install.packages("pacman")

--- a/app.R
+++ b/app.R
@@ -20,7 +20,7 @@ pacman::p_load(
 
 library(civis)
 library(mdiver)
-# library(bslib)
+library(bslib)
 library(scales)
 
 # Source ------------------------------------------------------------------------

--- a/app_server.R
+++ b/app_server.R
@@ -1,36 +1,36 @@
-server <-function(input, output, session) {
-  
+server <- function(input, output, session) {
+
   # Prevent "greying out" when running in Civis Platform
   observe(input$alive_count)
   session$allowReconnect("force")
-  
+
   screen_dim <- reactive({
     return(as.numeric(input$dimension))
   })
-  
+
   # observeEvent(input$dimension, {
-  #   
+  #
   #   ssize <- screen_dim()
-  #   
+  #
   #   ncols <- ifelse(ssize[1] < 980, 3, 5)
-  #   
+  #
   #   nrows <- as.integer(ceiling((length(ctry))/ncols))
-  #   
+  #
   #   print(paste0("ncol = ", ncols, ", nrows = ", nrows))
   # }, ignoreNULL = F)
-  
-  
-  
- 
-  
+
+
+
+
+
   # Trackers tab -----------------------------------------------------------------------------
-  
+
   # output$myplot1_track <- renderPlot({plot(runif(100), runif(100))})
   # output$myplot2_track <- renderPlot({plot(runif(100), runif(100))})
-  
-  
+
+
   ## > Update admin level 1 & 2 selection ------------
-  
+
   # observe({
   #   if ( (input$gres_track %in% c("admin1", "admin2")) ) {
   #     adm1_list <- get_choice_adm1(input$adm0_track)
@@ -46,12 +46,12 @@ server <-function(input, output, session) {
   #     output$adm1_track <- renderUI({NULL})
   #   }
   # })
-  
-  
+
+
   # observeEvent(c(input$gres_track, input$adm0_track, input$adm1_track), {
-  #   
+  #
   #   if (input$gres_track == "admin0") {
-  #     
+  #
   #     updatePickerInput(
   #       session = session, inputId = "adm0_track", options = list(`actions-box` = TRUE))
   #     updatePickerInput(
@@ -60,35 +60,35 @@ server <-function(input, output, session) {
   #       session = session, inputId = "adm2_track", choices = "None", selected = "None")
   #     shinyjs::disable("adm1_track")
   #     shinyjs::disable("adm2_track")
-  #     
+  #
   #   } else if (input$gres_track == "admin1") {
-  # 
+  #
   #     updatePickerInput(
   #       session = session, inputId = "adm2_track", choices = "None", selected = "None")
   #     updatePickerInput(
   #       session = session, inputId = "adm0_track", options = list(`actions-box` = TRUE), multiple = TRUE)
-  #     
+  #
   #     adm1_list <- get_choice_adm1(input$adm0_track)
-  #     
+  #
   #     if (any(input$adm1_track %in% adm1_list$selected)) {
   #       adm1_slctd <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
   #     } else {
   #       adm1_slctd <- adm1_list$selected
   #     }
-  #     
+  #
   #     updatePickerInput (
   #       session = session, inputId = "adm1_track",
   #       choices = adm1_list$choice, selected = adm1_slctd,
   #       options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'), multiple = TRUE)
-  #     
+  #
   #     shinyjs::enable("adm1_track")
   #     shinyjs::disable("adm2_track")
-  #     
+  #
   #   } else {
-  #     
+  #
   #     shinyjs::enable("adm1_track")
   #     shinyjs::enable("adm2_track")
-  #     
+  #
   #     if (length(input$adm0_track) > 3) {
   #       adm0_slctd <- input$adm0_track[1:3]
   #     } else {
@@ -98,10 +98,10 @@ server <-function(input, output, session) {
   #       session = session, inputId = "adm0_track", selected = adm0_slctd,
   #       options = list(`max-options` = 3, `actions-box` = TRUE), multiple = TRUE
   #     )
-  #     
+  #
   #     adm1_list <- get_choice_adm1(adm0_slctd)
   #     adm1_slctd <- adm1_list$selected
-  #     
+  #
   #     if (length(input$adm0_track > 1)) {
   #       if (any(input$adm1_track %in% adm1_list$selected)) {
   #         adm1_tmp <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
@@ -119,25 +119,23 @@ server <-function(input, output, session) {
   #         options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'), multiple = TRUE
   #       )
   #     }
-  #     
-  #     
-  #     
-  #     
-  #     
+  #
+  #
+  #
+  #
+  #
   #   }
-  #   
-  #   
-  #   
+  #
+  #
+  #
   # })
-  # 
-  
-  
+  #
+
+
   observeEvent(input$gres_track, {
-    
     nctry <- length(input$adm0_track)
-    
+
     if (input$gres_track == "admin0") {
-      
       updatePickerInput(
         session = session, inputId = "adm1_track",
         choices = "None", selected = "None"
@@ -152,124 +150,122 @@ server <-function(input, output, session) {
       )
       shinyjs::disable("adm1_track")
       shinyjs::disable("adm2_track")
-    
-      
     } else if (input$gres_track == "admin1") {
-      
-      if(nctry > 1) {
-        
-        if( nctry > 3) {
+      if (nctry > 1) {
+        if (nctry > 3) {
           adm0_slctd <- input$adm0_track[1:3]
         } else {
           adm0_slctd <- input$adm0_track
         }
-        
+
         updatePickerInput(
           session = session, inputId = "adm0_track", selected = adm0_slctd,
-          options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-        
+          options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+        )
       }
-      
+
       adm1_list <- get_choice_adm1(input$adm0_track)
-      
-      
+
+
       if (any(input$adm1_track %in% adm1_list$selected)) {
         adm1_slctd <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
       } else {
         adm1_slctd <- adm1_list$selected
       }
-      
-      if (length(adm1_slctd) > 30) {adm1_slctd <- adm1_slctd[1:30]}
-      
+
+      if (length(adm1_slctd) > 30) {
+        adm1_slctd <- adm1_slctd[1:30]
+      }
+
       if (nctry > 1) {
         nmax1 <- 30
       } else {
         nmax1 <- NULL
       }
-      
-      updatePickerInput (
-        session = session, inputId = "adm1_track", choices = adm1_list$choice, selected = adm1_list$selected, 
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3', `maxOptions` = nmax1))
-      
+
+      updatePickerInput(
+        session = session, inputId = "adm1_track", choices = adm1_list$choice, selected = adm1_list$selected,
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3", `maxOptions` = nmax1)
+      )
+
       updatePickerInput(
         session = session, inputId = "adm2_track",
         choices = "None", selected = "None"
       )
-      
+
       shinyjs::enable("adm1_track")
       shinyjs::disable("adm2_track")
-      
     } else {
-      
-      if( length(input$adm0_track) > 3) {
+      if (length(input$adm0_track) > 3) {
         adm0_slctd <- input$adm0_track[1:3]
       } else {
         adm0_slctd <- input$adm0_track
       }
-      
+
       updatePickerInput(
         session = session, inputId = "adm0_track", selected = adm0_slctd,
-        options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-      
+        options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
+
       adm1_list <- get_choice_adm1(input$adm0_track)
-      
+
       if (any(input$adm1_track %in% adm1_list$selected)) {
         adm1_tmp <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
         adm1_slctd <- adm1_tmp[1:(min(length(adm1_tmp), 5))]
       } else {
         adm1_slctd <- adm1_list$selected[1:5]
       }
-      
+
       if (nctry > 1) {
         nmax1 <- 30
       } else {
         nmax1 <- NULL
       }
-      
-      
+
+
       updatePickerInput(
-        session, inputId = "adm1_track", choices = adm1_list$choice, selected = adm1_slctd, 
-        options = list(`max-options` = nmax1, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-      
-      adm2_list <- get_choice_adm2(input$adm0_track, adm1_slctd)
-      
-      updatePickerInput(
-        session, inputId = "adm2_track", choices = adm2_list$choice, selected = adm2_list$selected, 
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3')
+        session,
+        inputId = "adm1_track", choices = adm1_list$choice, selected = adm1_slctd,
+        options = list(`max-options` = nmax1, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
       )
-      
+
+      adm2_list <- get_choice_adm2(input$adm0_track, adm1_slctd)
+
+      updatePickerInput(
+        session,
+        inputId = "adm2_track", choices = adm2_list$choice, selected = adm2_list$selected,
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
+
       shinyjs::enable("adm1_track")
       shinyjs::enable("adm2_track")
-      
     }
-    
-  }
-  )
-  
-  
-  
+  })
+
+
+
   # observeEvent(input$gres_track,{
-  #   
+  #
   #   if (input$gres_track == "admin2") {
-  #     
+  #
   #     if( length(input$adm0_track) > 3) {
   #       adm0_slctd <- input$adm0_track[1:3]
   #     } else {
   #       adm0_slctd <- input$adm0_track
   #     }
-  #     
+  #
   #     updatePickerInput(session, inputId = "adm0_track",
   #       options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'),
   #                        selected = adm0_slctd)
-  #     
+  #
   #     adm1_list <- get_choice_adm1(input$adm0_track)
-  #     
+  #
   #     if ( (all(input$adm1_track == "None")) & (any(input$adm1_track %in% adm1_list$selected)) ) {
   #       adm1_slctd <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
   #     } else {
   #       adm1_slctd <- adm1_list$selected
   #     }
-  # 
+  #
   #     if (all(input$adm1_track == "None")) {
   #       updatePickerInput (
   #         session = session, inputId = "adm1_track",
@@ -288,7 +284,7 @@ server <-function(input, output, session) {
   #           options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = 'count > 3')
   #         )
   #       }
-  # 
+  #
   #     }
   #     shinyjs::enable("adm1_track")
   #     shinyjs::enable("adm2_track")
@@ -301,15 +297,15 @@ server <-function(input, output, session) {
   #         options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
   #     } else {
   #       updatePickerInput (
-  #         session = session, inputId = "adm1_track", 
+  #         session = session, inputId = "adm1_track",
   #         options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
   #     }
-  # 
+  #
   #     updatePickerInput(
   #       session = session, inputId = "adm2_track",
   #       choices = "None", selected = "None"
   #     )
-  # 
+  #
   #     shinyjs::enable("adm1_track")
   #     shinyjs::disable("adm2_track")
   #   } else {
@@ -332,32 +328,33 @@ server <-function(input, output, session) {
 
 
 
-  observeEvent(input$adm0_track,{
-
+  observeEvent(input$adm0_track, {
     adm1_list <- get_choice_adm1(input$adm0_track)
 
-    if ( (any(input$adm1_track %in% "None")) & (any(input$adm1_track %in% adm1_list$selected)) ) {
+    if ((any(input$adm1_track %in% "None")) & (any(input$adm1_track %in% adm1_list$selected))) {
       adm1_slctd <- input$adm1_track[input$adm1_track %in% adm1_list$selected]
     } else {
       adm1_slctd <- adm1_list$selected
     }
 
     if (input$gres_track == "admin1") {
-      updatePickerInput (
+      updatePickerInput(
         session = session, inputId = "adm1_track",
         choices = adm1_list$choice, selected = adm1_slctd,
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
     } else if (input$gres_track == "admin2") {
-      if(length(input$adm0_track) > 1){
+      if (length(input$adm0_track) > 1) {
         updatePickerInput(
-          session = session, inputId  = "adm1_track",
+          session = session, inputId = "adm1_track",
           choices = adm1_list$choice, selected = adm1_slctd[1:5],
-          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = 'count > 3'))
+          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = "count > 3")
+        )
       } else {
         updatePickerInput(
-          session = session, inputId  = "adm1_track",
+          session = session, inputId = "adm1_track",
           choices = adm1_list$choice, selected = adm1_slctd[1:5],
-          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = 'count > 3')
+          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = "count > 3")
         )
       }
     }
@@ -365,24 +362,25 @@ server <-function(input, output, session) {
 
 
   observeEvent(input$adm1_track, {
-    if (input$gres_track == "admin2")  {
+    if (input$gres_track == "admin2") {
       adm2_list <- get_choice_adm2(input$adm0_track, input$adm1_track)
       updatePickerInput(
-        session = session, inputId  = "adm2_track",
+        session = session, inputId = "adm2_track",
         choices = adm2_list$choice, selected = adm2_list$selected,
-        options = list(`action-box` = TRUE, `selectedTextFormat` = 'count > 3')
+        options = list(`action-box` = TRUE, `selectedTextFormat` = "count > 3")
       )
     }
   })
 
 
-  
-  
+
+
   ## > Hide & Show Filter panel -----------------------
-  
+
   # Close filter
   observeEvent(
-    input$bt2mini_track, {
+    input$bt2mini_track,
+    {
       shinyjs::hide("filter_track")
       shinyjs::show("filter_hidden_track")
       shinyjs::runjs("$('#plot_panel_track').
@@ -391,7 +389,7 @@ server <-function(input, output, session) {
       shinyjs::runjs("$(window).trigger('resize')")
     }
   )
-  
+
   # Open filter
   # observeEvent(
   #   input$bt2maxi_track, {
@@ -403,103 +401,107 @@ server <-function(input, output, session) {
   #     shinyjs::runjs("$(window).trigger('resize')")
   #   }
   # )
-  
-  
+
+
   ## > Plot seasonal trackers --------------------------
-  
-  lgnd_par <- eventReactive(input$goplot_track, {
-    
-    ev <- get_ev_par(input$ev_track)
-    epi <- get_epi_par(input$epi_track)
-    
-    return(list(ev = ev, epi = epi))
-    
-  }, ignoreNULL = F)
-  
-  
+
+  lgnd_par <- eventReactive(input$goplot_track,
+    {
+      ev <- get_ev_par(input$ev_track)
+      epi <- get_epi_par(input$epi_track)
+
+      return(list(ev = ev, epi = epi))
+    },
+    ignoreNULL = F
+  )
+
+
   output$legend_ssn <- renderUI({
-    
     par <- lgnd_par()
-    
+
     yrs <- sort(input$year_ssn)
-    
-    # ev <- get_ev_par(input$ev_track) 
-    
+
+    # ev <- get_ev_par(input$ev_track)
+
     line_seq <- rev(rev(lgnd_seq)[1:length(yrs)])
-    
+
     ltxt <- paste0("<br><b>", par$ev$label, "</b>: &nbsp;&nbsp;", "<span style='background-color:#cccccc'>&nbsp;&nbsp;&nbsp; &nbsp; </span> &nbsp;
-      Historical Range &nbsp; &nbsp; 
+      Historical Range &nbsp; &nbsp;
       <font color = #999999> -&nbsp;-&nbsp;-&nbsp;-&nbsp;</font> &nbsp; Historical Average ")
-    
-    for(i in 1:length(yrs)) {
-      ltxt <- paste0(ltxt, "&nbsp;&nbsp;&nbsp;&nbsp;", 
-             "<span class = ", line_seq[i], "></span> &nbsp; ", yrs[i])
+
+    for (i in 1:length(yrs)) {
+      ltxt <- paste0(
+        ltxt, "&nbsp;&nbsp;&nbsp;&nbsp;",
+        "<span class = ", line_seq[i], "></span> &nbsp; ", yrs[i]
+      )
     }
-    
-    if(par$epi$unit != "unknown variable") {
-      
+
+    if (par$epi$unit != "unknown variable") {
       line_seq_epi <- rev(rev(lgnd_epi_seq)[1:length(yrs)])
       ltxt <- paste0(ltxt, "<br><b>", par$epi$label, "</b>:")
-      for(i in 1:length(yrs)) {
-        ltxt <- paste0(ltxt, "&nbsp;&nbsp;&nbsp;&nbsp;", 
-                       # "<div class = ", line_seq_epi[i], "> <div class = 'circle'> </div></div> &nbsp; ", yrs[i])
-                       "<span class = ", line_seq_epi[i], "></span> &nbsp; ", yrs[i])
+      for (i in 1:length(yrs)) {
+        ltxt <- paste0(
+          ltxt, "&nbsp;&nbsp;&nbsp;&nbsp;",
+          # "<div class = ", line_seq_epi[i], "> <div class = 'circle'> </div></div> &nbsp; ", yrs[i])
+          "<span class = ", line_seq_epi[i], "></span> &nbsp; ", yrs[i]
+        )
       }
-      
-      
     }
-    
+
     # qq <- xmain()
     # ssize <- screen_dim()
-    # 
+    #
     # # tt0 <- proc.time()
-    # 
+    #
     # qq$df <- qq$df %>%
     #   filter(year %in% as.numeric(input$year_ssn))
     # qq$yrs <- as.numeric(input$year_ssn)
-    # 
+    #
     # yax_std <- ifelse(qq$yax_ssn == "Same", TRUE, FALSE)
-    # 
-    # 
+    #
+    #
     # uu <- get_dummy(u = qq$df, ev = qq$ev, epi = qq$epi, agg = qq$agg, yrs = qq$yrs, ssn = "cy", yax_std = yax_std, ssize = ssize)
     # ltxt <- paste0(ltxt, " <br>Epi data = ", paste0(names(uu), collapse = ", "))
-    
-    
+
+
     # HTML(
     #   " <span style='background-color:#cccccc'>&nbsp;&nbsp;&nbsp;&nbsp; &nbsp; </span> &nbsp;
     #   Historical Range &nbsp; &nbsp; &nbsp;
-    #   <font color = #999999> -&nbsp;-&nbsp;-&nbsp;-&nbsp;</font> &nbsp; Historical Average &nbsp;&nbsp;&nbsp;&nbsp; 
-    #   <span class = 'linered'></span> &nbsp; 20xx &nbsp;&nbsp;&nbsp;&nbsp; 
+    #   <font color = #999999> -&nbsp;-&nbsp;-&nbsp;-&nbsp;</font> &nbsp; Historical Average &nbsp;&nbsp;&nbsp;&nbsp;
+    #   <span class = 'linered'></span> &nbsp; 20xx &nbsp;&nbsp;&nbsp;&nbsp;
     #   <span class = 'lineblue'></span> &nbsp; 20xx")
-    
+
     HTML(ltxt)
   })
-  
 
-  
-  xmain <- eventReactive (input$goplot_track, {
-    
-    if(input$epi_track == "none") {
-      epi <- NULL
-    } else {
-      epi <- input$epi_track
-    }
-        get_data_main(adm_res = input$gres_track, gid0 = input$adm0_track, 
-                      gid1 = input$adm1_track, gid2 = input$adm2_track, ev = input$ev_track, epi = epi)
-  }, ignoreNULL = F)
-  
 
-  
+
+  xmain <- eventReactive(input$goplot_track,
+    {
+      if (input$epi_track == "none") {
+        epi <- NULL
+      } else {
+        epi <- input$epi_track
+      }
+      get_data_main(
+        adm_res = input$gres_track, gid0 = input$adm0_track,
+        gid1 = input$adm1_track, gid2 = input$adm2_track, ev = input$ev_track, epi = epi
+      )
+    },
+    ignoreNULL = F
+  )
+
+
+
   # output$test_out <- renderText({
   # #   dtest <- xmain()
   # #   paste("agg = ", dtest$agg, "\n ev = ", dtest$ev, "\n yrs = ", paste0(dtest$yrs, collapse = ", "))
   # #   paste0(head(dtest$df))
   #   paste(input$adm1_track, collapse = ", ")
   # })
-  
+
 
   output$myplot1_track <- renderPlotly({
-    
     ssize <- screen_dim()
 
     # tt0 <- proc.time()
@@ -508,17 +510,17 @@ server <-function(input, output, session) {
     x2pl$df <- x2pl$df %>%
       filter(year %in% as.numeric(input$year_ssn))
     x2pl$yrs <- as.numeric(input$year_ssn)
-    
+
     yax_std <- ifelse(input$yax_ssn == "Same", TRUE, FALSE)
 
     tt1 <- proc.time()
-    
-    if(input$sort_ssn == "Alphabetically") {
+
+    if (input$sort_ssn == "Alphabetically") {
       order <- "alpha"
     } else {
       order <- "lat"
     }
-    
+
 
     uu <- get_plot_ssn(u = x2pl$df, ev = x2pl$ev, epi = x2pl$epi, agg = x2pl$agg, yrs = x2pl$yrs, ssn = "cy", yax_std = yax_std, ssize = ssize, order = order)
 
@@ -532,44 +534,39 @@ server <-function(input, output, session) {
     # })
 
     return(uu)
-
   })
-  
-  
+
+
   output$test_out2 <- renderText({
-      paste0(paste0(input$date_histo, collapse = ", "), " class = ", class(input$date_histo))
-    })
-  
-  
-  
-  
+    paste0(paste0(input$date_histo, collapse = ", "), " class = ", class(input$date_histo))
+  })
+
+
+
+
   output$myplot2_track <- renderPlotly({
-    
     ssize <- screen_dim()
-    
+
     x2pl <- xmain()
     x2pl$df <- x2pl$df %>%
       filter((date >= input$date_histo[1]) & (date <= input$date_histo[2]))
     x2pl$yrs <- as.numeric(input$year_ssn)
-    
+
     yax_std <- ifelse(input$yax_histo == "Same", TRUE, FALSE)
-    
+
     uu <- get_plot_histo(u = x2pl$df, ev = x2pl$ev, epi = x2pl$epi, agg = x2pl$agg, date_range = input$date_histo, ssn = "cy", yax_std = yax_std, ssize = ssize)
-    
+
     return(uu)
-    
   })
-  
-  
-  
+
+
+
   # Download Tab -------------------------------------------------------------------------------------
-  
+
   observeEvent(input$gres_down, {
-    
     nctry <- length(input$adm0_down)
-    
+
     if (input$gres_down == "admin0") {
-      
       updatePickerInput(
         session = session, inputId = "adm1_down",
         choices = "None", selected = "None"
@@ -584,195 +581,203 @@ server <-function(input, output, session) {
       )
       shinyjs::disable("adm1_down")
       shinyjs::disable("adm2_down")
-      
-      
     } else if (input$gres_down == "admin1") {
-      
-      if(nctry > 1) {
-        
-        if( nctry > 3) {
+      if (nctry > 1) {
+        if (nctry > 3) {
           adm0_slctd <- input$adm0_down[1:3]
         } else {
           adm0_slctd <- input$adm0_down
         }
-        
+
         updatePickerInput(
           session = session, inputId = "adm0_down", selected = adm0_slctd,
-          options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-        
+          options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+        )
       }
-      
+
       adm1_list <- get_choice_adm1(input$adm0_down)
-      
-      
+
+
       if (any(input$adm1_down %in% adm1_list$selected)) {
         adm1_slctd <- input$adm1_down[input$adm1_down %in% adm1_list$selected]
       } else {
         adm1_slctd <- adm1_list$selected
       }
-      
-      if (length(adm1_slctd) > 30) {adm1_slctd <- adm1_slctd[1:30]}
-      
+
+      if (length(adm1_slctd) > 30) {
+        adm1_slctd <- adm1_slctd[1:30]
+      }
+
       if (nctry > 1) {
         nmax1 <- 30
       } else {
         nmax1 <- NULL
       }
-      
-      updatePickerInput (
-        session = session, inputId = "adm1_down", choices = adm1_list$choice, selected = adm1_list$selected, 
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3', `maxOptions` = nmax1))
-      
+
+      updatePickerInput(
+        session = session, inputId = "adm1_down", choices = adm1_list$choice, selected = adm1_list$selected,
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3", `maxOptions` = nmax1)
+      )
+
       updatePickerInput(
         session = session, inputId = "adm2_down",
         choices = "None", selected = "None"
       )
-      
+
       shinyjs::enable("adm1_down")
       shinyjs::disable("adm2_down")
-      
     } else {
-      
-      if( length(input$adm0_down) > 3) {
+      if (length(input$adm0_down) > 3) {
         adm0_slctd <- input$adm0_down[1:3]
       } else {
         adm0_slctd <- input$adm0_down
       }
-      
+
       updatePickerInput(
         session = session, inputId = "adm0_down", selected = adm0_slctd,
-        options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-      
+        options = list(`max-options` = 3, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
+
       adm1_list <- get_choice_adm1(input$adm0_down)
-      
+
       if (any(input$adm1_down %in% adm1_list$selected)) {
         adm1_tmp <- input$adm1_down[input$adm1_down %in% adm1_list$selected]
         adm1_slctd <- adm1_tmp[1:(min(length(adm1_tmp), 5))]
       } else {
         adm1_slctd <- adm1_list$selected[1:5]
       }
-      
+
       if (nctry > 1) {
         nmax1 <- 30
       } else {
         nmax1 <- NULL
       }
-      
-      
+
+
       updatePickerInput(
-        session, inputId = "adm1_down", choices = adm1_list$choice, selected = adm1_slctd, 
-        options = list(`max-options` = nmax1, `actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
-      
-      adm2_list <- get_choice_adm2(input$adm0_down, adm1_slctd)
-      
-      updatePickerInput(
-        session, inputId = "adm2_down", choices = adm2_list$choice, selected = adm2_list$selected, 
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3')
+        session,
+        inputId = "adm1_down", choices = adm1_list$choice, selected = adm1_slctd,
+        options = list(`max-options` = nmax1, `actions-box` = TRUE, `selectedTextFormat` = "count > 3")
       )
-      
+
+      adm2_list <- get_choice_adm2(input$adm0_down, adm1_slctd)
+
+      updatePickerInput(
+        session,
+        inputId = "adm2_down", choices = adm2_list$choice, selected = adm2_list$selected,
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
+
       shinyjs::enable("adm1_down")
       shinyjs::enable("adm2_down")
-      
     }
-    
-  }
-  )
-  
-  
-  observeEvent(input$adm0_down,{
-    
+  })
+
+
+  observeEvent(input$adm0_down, {
     adm1_list <- get_choice_adm1(input$adm0_down)
-    
-    if ( (any(input$adm1_down %in% "None")) & (any(input$adm1_down %in% adm1_list$selected)) ) {
+
+    if ((any(input$adm1_down %in% "None")) & (any(input$adm1_down %in% adm1_list$selected))) {
       adm1_slctd <- input$adm1_down[input$adm1_down %in% adm1_list$selected]
     } else {
       adm1_slctd <- adm1_list$selected
     }
-    
+
     if (input$gres_down == "admin1") {
-      updatePickerInput (
+      updatePickerInput(
         session = session, inputId = "adm1_down",
         choices = adm1_list$choice, selected = adm1_slctd,
-        options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'))
+        options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3")
+      )
     } else if (input$gres_down == "admin2") {
-      if(length(input$adm0_down) > 1){
+      if (length(input$adm0_down) > 1) {
         updatePickerInput(
-          session = session, inputId  = "adm1_down",
+          session = session, inputId = "adm1_down",
           choices = adm1_list$choice, selected = adm1_slctd[1:5],
-          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = 'count > 3'))
+          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = "count > 3")
+        )
       } else {
         updatePickerInput(
-          session = session, inputId  = "adm1_down",
+          session = session, inputId = "adm1_down",
           choices = adm1_list$choice, selected = adm1_slctd[1:5],
-          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = 'count > 3')
+          options = list(`action-box` = TRUE, `max-options` = 5, `selectedTextFormat` = "count > 3")
         )
       }
     }
   })
-  
-  
+
+
   observeEvent(input$adm1_down, {
-    if (input$gres_down == "admin2")  {
+    if (input$gres_down == "admin2") {
       adm2_list <- get_choice_adm2(input$adm0_down, input$adm1_down)
       updatePickerInput(
-        session = session, inputId  = "adm2_down",
+        session = session, inputId = "adm2_down",
         choices = adm2_list$choice, selected = adm2_list$selected,
-        options = list(`action-box` = TRUE, `selectedTextFormat` = 'count > 3')
+        options = list(`action-box` = TRUE, `selectedTextFormat` = "count > 3")
       )
     }
   })
-  
-  
-  
-  xtab <- eventReactive (input$godata, {
-    
-    if(input$gres_down == "admin0") {
-      gid <- input$adm0_down; agg <- 0; adm_var <- "country"
-    } else if (input$gres_down == "admin1") {
-      gid <- input$adm1_down; agg <- 1; adm_var <- c("country", "admin_level_1")
-    } else {
-      gid <- input$adm2_down; agg <- 2; adm_var <- c("country", "admin_level_1", "admin_level_2")
-    }
-    
-    # y <- x0 %>%
-    #   filter((geo_id %in% gid) & (variable_name %in% input$ev_down) & (date >= input$date_down[1]) & (date <= input$date_down[2])) %>%
-    #   select(c(all_of(adm_var), variable_name, date, value, monthly_ave, minval, maxval)) %>%
-    #   rename(longterm_mean = monthly_ave, longterm_min = minval, longterm_max = maxval)
-    
-    nev <- length(input$ev_down)
-    qev <- ifelse(nev == 1, paste0("= '", input$ev_down, "'"), 
-                  paste0("IN (", paste0(paste0("'", input$ev_down, "'"), collapse = ", "), ")"))
-    
-    query <- paste0("SELECT geo_id,", adm_var, 
-                ", variable_name, date, value monthly_ave, minval, maxval 
+
+
+
+  xtab <- eventReactive(input$godata,
+    {
+      if (input$gres_down == "admin0") {
+        gid <- input$adm0_down
+        agg <- 0
+        adm_var <- "country"
+      } else if (input$gres_down == "admin1") {
+        gid <- input$adm1_down
+        agg <- 1
+        adm_var <- c("country", "admin_level_1")
+      } else {
+        gid <- input$adm2_down
+        agg <- 2
+        adm_var <- c("country", "admin_level_1", "admin_level_2")
+      }
+
+      # y <- x0 %>%
+      #   filter((geo_id %in% gid) & (variable_name %in% input$ev_down) & (date >= input$date_down[1]) & (date <= input$date_down[2])) %>%
+      #   select(c(all_of(adm_var), variable_name, date, value, monthly_ave, minval, maxval)) %>%
+      #   rename(longterm_mean = monthly_ave, longterm_min = minval, longterm_max = maxval)
+
+      nev <- length(input$ev_down)
+      qev <- ifelse(nev == 1, paste0("= '", input$ev_down, "'"),
+        paste0("IN (", paste0(paste0("'", input$ev_down, "'"), collapse = ", "), ")")
+      )
+
+      query <- paste0(
+        "SELECT geo_id,", adm_var,
+        ", variable_name, date, value monthly_ave, minval, maxval
                 FROM staging_pmihq.climate_app WHERE ",
-                "geo_id IN (", paste0(gid, collapse = ", "), ") AND ",
-                "variable_name ", qev,  " AND (date BETWEEN '", input$date_down[1], "' AND '", input$date_down[2], "');") 
-    
-    
-    y <- read_civis(sql(query),
-                    database = "PMI") %>%
-      mutate(date = as.Date(as.character(date)))
-    
-    return(y)
-    
-  }, ignoreNULL = T)
-  
-  
+        "geo_id IN (", paste0(gid, collapse = ", "), ") AND ",
+        "variable_name ", qev, " AND (date BETWEEN '", input$date_down[1], "' AND '", input$date_down[2], "');"
+      )
+
+
+      y <- read_civis(sql(query),
+        database = "PMI"
+      ) %>%
+        mutate(date = as.Date(as.character(date)))
+
+      return(y)
+    },
+    ignoreNULL = T
+  )
+
+
   output$table <- renderTable({
     yy <- xtab()
-    yy[1:10,]
+    yy[1:10, ]
   })
-  
-  
+
+
   output$download_btn <- downloadHandler(
     filename <- function() {
-      paste0("MDIVE_", paste0(input$ev_down, collapse = "_"), '.csv')
+      paste0("MDIVE_", paste0(input$ev_down, collapse = "_"), ".csv")
     },
-    content = function(file){
+    content = function(file) {
       write.csv(xtab(), file, row.names = F)
     }
   )
-  
 }
-

--- a/app_server.R
+++ b/app_server.R
@@ -750,7 +750,8 @@ server <-function(input, output, session) {
                 "variable_name ", qev,  " AND (date BETWEEN '", input$date_down[1], "' AND '", input$date_down[2], "');") 
     
     
-    y <- read_civis(sql(query)) %>%
+    y <- read_civis(sql(query),
+                    database = "PMI") %>%
       mutate(date = as.Date(as.character(date)))
     
     return(y)

--- a/app_ui.R
+++ b/app_ui.R
@@ -1,31 +1,29 @@
 ui <- navbarPage(
-  
+
   # includeCSS("www/style.css"),
   # theme = shinytheme("cerulean"),
-  
+
   # bslib::page_navbar(
   # navbarPage(
-    
-    # theme = bs_theme(bootswatch = "paper", version = 3, 
-    #                  fg = "black", bg = "white"),
-   
-    
 
-    
-    # tab_home,
-    tab_trackers,
-    #tab_compare,
-    #tab_download,
-    #tab_docs,
-    # tabPanel("Compare/Overlay"),
-    tab_download,
-    
-    title = "CLIMATE",
-    # window_title = "CLIMATE",
+  # theme = bs_theme(bootswatch = "paper", version = 3,
+  #                  fg = "black", bg = "white"),
+
+
+
+
+  # tab_home,
+  tab_trackers,
+  # tab_compare,
+  # tab_download,
+  # tab_docs,
+  # tabPanel("Compare/Overlay"),
+  tab_download,
+  title = "CLIMATE",
+  # window_title = "CLIMATE",
   windowTitle = "CLIMATE",
-    inverse = F
-    
-    
+  inverse = F
+
+
   # )
-  
 )

--- a/downloads.R
+++ b/downloads.R
@@ -1,4 +1,4 @@
-tab_download <- 
+tab_download <-
   tabPanel(
     "Downloads",
     fluidPage(
@@ -7,59 +7,85 @@ tab_download <-
           style = "padding-bottom: 4px; padding-top:4px;font-size:12px;",
           fluidRow(
             column(width = 6, HTML("<h5>FILTER</h5>")),
-            column(width = 6, align = "right", 
-                   actionButton(inputId = "godata", label = "Get Data", 
-                                class = "btn-primary", style = "margin-top:10px;"))
+            column(
+              width = 6, align = "right",
+              actionButton(
+                inputId = "godata", label = "Get Data",
+                class = "btn-primary", style = "margin-top:10px;"
+              )
+            )
           ),
           fluidRow(
             style = "margin-top:4px; margin-bottom:0px;padding-bottom:0px; padding-top:0px;margin-bottom:0px;",
-            column (width = 4, # style = "margin-top:-5px;",
-              div(class = "smalbox",
-                pickerInput( 
+            column(
+              width = 4, # style = "margin-top:-5px;",
+              div(
+                class = "smalbox",
+                pickerInput(
                   inputId = "ev_down", label = HTML("Climate Variable"),
-                  choices = c("Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair",
-                              "Land Surface Temperature" = "lstd",
-                              "Vegetation Index" = "ndvi", "Specific Humidity" = "sh", "Soil Moisture" = "sm"),
-                  selected = "rf", options = list(`actions-box` = TRUE), multiple = TRUE)
+                  choices = c(
+                    "Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair",
+                    "Land Surface Temperature" = "lstd",
+                    "Vegetation Index" = "ndvi", "Specific Humidity" = "sh", "Soil Moisture" = "sm"
+                  ),
+                  selected = "rf", options = list(`actions-box` = TRUE), multiple = TRUE
+                )
               )
             ),
-            div(class = "smallbox",
-            column(width = 4, 
-                   airDatepickerInput(inputId = "date_down", label = HTML("<b>Date Range</b>"), range = TRUE, 
-                                      view = "months", minView = "months", clearButton = T, update_on = "close",
-                                      dateFormat = "MMM yyyy", monthsField = "monthsShort", separator = " to ",
-                                      minDate = as.Date("2017-01-01"), maxDate = date_now, value = c(as.Date("2017-01-01"), date_now))
-            )),
-            
-            column (width = 4,
-                    selectizeInput (
-                      inputId = "gres_down", label = HTML("Geographical Aggregation"),
-                      choices = c("National (Country)" = "admin0", "Admin. Level 1" = "admin1", "Admin. Level 2" = "admin2"),
-                      selected = "admin0"
-                    ))
+            div(
+              class = "smallbox",
+              column(
+                width = 4,
+                airDatepickerInput(
+                  inputId = "date_down", label = HTML("<b>Date Range</b>"), range = TRUE,
+                  view = "months", minView = "months", clearButton = T, update_on = "close",
+                  dateFormat = "MMM yyyy", monthsField = "monthsShort", separator = " to ",
+                  minDate = as.Date("2017-01-01"), maxDate = date_now, value = c(as.Date("2017-01-01"), date_now)
+                )
+              )
+            ),
+            column(
+              width = 4,
+              selectizeInput(
+                inputId = "gres_down", label = HTML("Geographical Aggregation"),
+                choices = c("National (Country)" = "admin0", "Admin. Level 1" = "admin1", "Admin. Level 2" = "admin2"),
+                selected = "admin0"
+              )
+            )
           ),
           fluidRow(
             style = "margin-top:0px; margin-bottom:1px;padding-bottom:1px;padding-top:0px;",
-            column (width = 4, style = "margin-top:-14px;",
-                    div(class = "smallbox",
-                        pickerInput(
-                          inputId = "adm0_down", label = HTML("Country"),
-                          choices = adm0_choice, selected = as.vector(adm0_choice),
-                          options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'), multiple = TRUE))),
-            
-            column (width = 4,  style = "margin-top:-10px;",
-                    div(class = "smallbox",
-                        pickerInput(
-                          inputId = "adm1_down", label = HTML("Admin. Level 1"),
-                          choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE))),
-            
-            column(width = 4,  style = "margin-top:-10px;",
-                   div(class = "smallbox",
-                       pickerInput(
-                         inputId = "adm2_down", label = HTML("Admin. Level 2"),
-                         choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
-                       )))
-            
+            column(
+              width = 4, style = "margin-top:-14px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm0_down", label = HTML("Country"),
+                  choices = adm0_choice, selected = as.vector(adm0_choice),
+                  options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3"), multiple = TRUE
+                )
+              )
+            ),
+            column(
+              width = 4, style = "margin-top:-10px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm1_down", label = HTML("Admin. Level 1"),
+                  choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
+                )
+              )
+            ),
+            column(
+              width = 4, style = "margin-top:-10px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm2_down", label = HTML("Admin. Level 2"),
+                  choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
+                )
+              )
+            )
           )
         )
       ),
@@ -70,23 +96,13 @@ tab_download <-
           width = 6, HTML("<H4> Table Preview </H4> (first 10 rows)")
         ),
         column(
-          width = 6, align = "right", 
-          downloadButton("download_btn", label = "Download", 
-                       class = "btn-primary", style = "margin-top:10px;")
+          width = 6, align = "right",
+          downloadButton("download_btn",
+            label = "Download",
+            class = "btn-primary", style = "margin-top:10px;"
+          )
         )
       ),
       tableOutput("table")
-      
     )
   )
-
-
-
-
-
-
-
-
-
-
-

--- a/fun.R
+++ b/fun.R
@@ -781,7 +781,8 @@ get_plot_histo <- function(u, ev = NULL, epi = NULL, agg, date_range, ssn = "cy"
   ncols <- min(5, length(pp))
   subplot(pp,
     nrows = nrows, # , margin = c(0.03, 0.03, 0.03, 0.03)#,
-    widths = rep(signif(0.98 / ncols, digits = 3), ncols), heights = rep(signif(0.98 / nrows, digits = 5), nrows)
+    widths = rep(signif(0.98 / 5, digits = 3), times = ncols), 
+    heights = rep(signif(0.98 / nrows, digits = 5), times = nrows)
   ) %>%
     layout(showlegend = F)
 }

--- a/fun.R
+++ b/fun.R
@@ -80,7 +80,7 @@ get_choice_adm2 <- function(ctry_list, adm1_list) {
 # xu <- get_data_main(adm_res = "admin0", gid, gid1 = NULL, gid2 = NULL, ev = ev)
 
 
-get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
+get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
   if (adm_res == "admin0") {
     gid <- gid0
     agg <- 0
@@ -105,6 +105,7 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
     database = "PMI"
   ) %>%
     mutate(date = as.Date(as.character(date)))
+  y <- mdiver::user_level_filter_data(y, user =  userid)
 
   n0 <- length(unique(y$country))
   n1 <- length(unique(y$admin_level_1))

--- a/fun.R
+++ b/fun.R
@@ -91,25 +91,29 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
     gid <- gid2
     agg <- 2
   }
-
-  query <- paste0(
-    "SELECT * FROM staging_pmihq.climate_app WHERE ",
-    "geo_id IN (", paste0(gid, collapse = ", "), ") AND ",
-    "variable_name = '", ev, "' AND aggregation_level = ", agg
-  )
-
-  # y <- x0 %>%
-  #   filter((geo_id %in% gid) & (variable_name == ev) & (aggregation_level == agg))
-
-  y <- read_civis(sql(query),
-    database = "PMI"
-  ) %>%
-    mutate(date = as.Date(as.character(date)))
+  
+  # query <- paste0(
+  #   "SELECT * FROM staging_pmihq.climate_app WHERE ",
+  #   "geo_id IN ('", paste0(gid, collapse = "', '"), "') AND ",
+  #   "variable_name = '", ev, "' AND aggregation_level = ", agg
+  # )
+  #
+  # y <- read_civis(sql(query),
+  #   database = "PMI"
+  # ) %>%
+  #   mutate(date = as.Date(as.character(date)))
+  
+  y <- df_all %>%
+    filter(
+      geo_id %in% gid,
+      variable_name == ev,
+      aggregation_level == agg
+    )
   y <- mdiver::user_level_filter_data(y, user =  userid)
-
+  
   n0 <- length(unique(y$country))
   n1 <- length(unique(y$admin_level_1))
-
+  
   if ((n0 == 1) & (n1 <= 1)) {
     y$adm_label <- y$adm_label_tmp
   } else if ((n0 == 1) & (n1 > 1)) {
@@ -127,8 +131,9 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
       y$adm_label <- y$adm_label012
     }
   }
-
-  y <- y %>% select(-c(adm_label_tmp, adm_label01, adm_label012, adm_label12))
+  
+  y <- y %>% 
+    select(-c(adm_label_tmp, adm_label01, adm_label012, adm_label12))
   out <- list(df = y, agg = agg, ev = ev, epi = epi)
 
   return(out)

--- a/fun.R
+++ b/fun.R
@@ -83,7 +83,8 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
   # y <- x0 %>%
   #   filter((geo_id %in% gid) & (variable_name == ev) & (aggregation_level == agg)) 
   
-  y <- read_civis(sql(query)) %>%
+  y <- read_civis(sql(query),
+                  database = "PMI") %>%
     mutate(date = as.Date(as.character(date)))
   
   n0 <- length(unique(y$country))

--- a/fun.R
+++ b/fun.R
@@ -1,20 +1,28 @@
 
 get_choice_adm1 <- function(ctry_list) {
-  
   ctry_str <- adm_master %>%
-    filter(geo_id %in% ctry_list) %>% pull(country)
-  
+    filter(geo_id %in% ctry_list) %>%
+    pull(country)
+
   y <- adm_master %>%
-    filter( (aggregation_level == 1) & (country %in% ctry_str) ) %>%
+    filter((aggregation_level == 1) & (country %in% ctry_str)) %>%
     arrange(country, admin_level_1)
   n <- length(ctry_list)
   if (n == 1) {
-    ychoice <- unlist(map2(y$admin_level_1, as.character(y$geo_id),
-                           ~ {names(.y) <- .x; .y}))
+    ychoice <- unlist(map2(
+      y$admin_level_1, as.character(y$geo_id),
+      ~ {
+        names(.y) <- .x
+        .y
+      }
+    ))
   } else if (n > 1) {
     anames <- split(y$admin_level_1, y$country)
     avals <- split(as.character(y$geo_id), y$country)
-    ychoice <- map2(anames, avals, ~ {names(.y) <- .x; .y})
+    ychoice <- map2(anames, avals, ~ {
+      names(.y) <- .x
+      .y
+    })
   } else {
     ychoice <- NULL
   }
@@ -23,31 +31,37 @@ get_choice_adm1 <- function(ctry_list) {
 
 
 get_choice_adm2 <- function(ctry_list, adm1_list) {
-  
   if (is.null(adm1_list) | (length(adm1_list) == 0) | all(tolower(adm1_list) == "none")) {
     geo_tmp <- adm_master %>% filter(geo_id %in% ctry_list)
     adm1_list <- adm_master %>% filter((country %in% geo_tmp$country) & (aggregation_level == 1))
   }
-  
+
   area_str <- adm_master %>%
-    filter(geo_id %in% adm1_list) %>% select(country, admin_level_1)
-  
+    filter(geo_id %in% adm1_list) %>%
+    select(country, admin_level_1)
+
   y <- adm_master %>%
-    filter( (aggregation_level == 2) & (country %in% unique(area_str$country)) & (admin_level_1 %in% area_str$admin_level_1)) %>%
+    filter((aggregation_level == 2) & (country %in% unique(area_str$country)) & (admin_level_1 %in% area_str$admin_level_1)) %>%
     arrange(country, admin_level_1, admin_level_2)
-  
+
   nctry <- length(ctry_list)
-  
-  if(nctry == 1) {
+
+  if (nctry == 1) {
     anames <- split(y$admin_level_2, y$admin_level_1)
     avals <- split(as.character(y$geo_id), y$admin_level_1)
-    ychoice <- map2(anames, avals, ~ {names(.y) <- .x; .y})
+    ychoice <- map2(anames, avals, ~ {
+      names(.y) <- .x
+      .y
+    })
   } else if (nctry > 1) {
     y <- y %>%
       mutate(adm2head = paste(country, admin_level_1, sep = " | "))
     anames <- split(y$admin_level_2, y$adm2head)
     avals <- split(as.character(y$geo_id), y$adm2head)
-    ychoice <- map2(anames, avals, ~ {names(.y) <- .x; .y})
+    ychoice <- map2(anames, avals, ~ {
+      names(.y) <- .x
+      .y
+    })
   } else {
     ychoice <- NULL
   }
@@ -67,36 +81,41 @@ get_choice_adm2 <- function(ctry_list, adm1_list) {
 
 
 get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
-  
-  if(adm_res == "admin0") {
-    gid <- gid0; agg <- 0
+  if (adm_res == "admin0") {
+    gid <- gid0
+    agg <- 0
   } else if (adm_res == "admin1") {
-    gid <- gid1; agg <- 1
+    gid <- gid1
+    agg <- 1
   } else {
-    gid <- gid2; agg <- 2
+    gid <- gid2
+    agg <- 2
   }
-  
-  query <- paste0("SELECT * FROM staging_pmihq.climate_app WHERE ",
-                  "geo_id IN (", paste0(gid, collapse = ", "), ") AND ",
-                  "variable_name = '", ev, "' AND aggregation_level = ", agg)
-  
+
+  query <- paste0(
+    "SELECT * FROM staging_pmihq.climate_app WHERE ",
+    "geo_id IN (", paste0(gid, collapse = ", "), ") AND ",
+    "variable_name = '", ev, "' AND aggregation_level = ", agg
+  )
+
   # y <- x0 %>%
-  #   filter((geo_id %in% gid) & (variable_name == ev) & (aggregation_level == agg)) 
-  
+  #   filter((geo_id %in% gid) & (variable_name == ev) & (aggregation_level == agg))
+
   y <- read_civis(sql(query),
-                  database = "PMI") %>%
+    database = "PMI"
+  ) %>%
     mutate(date = as.Date(as.character(date)))
-  
+
   n0 <- length(unique(y$country))
   n1 <- length(unique(y$admin_level_1))
-  
-  if ( (n0 == 1) & (n1 <= 1) ) {
+
+  if ((n0 == 1) & (n1 <= 1)) {
     y$adm_label <- y$adm_label_tmp
-  } else if ((n0 == 1) & (n1 >1)) {
+  } else if ((n0 == 1) & (n1 > 1)) {
     if (agg == 1) {
       y$adm_label <- y$adm_label_tmp
     } else {
-      y$adm_label <- y $adm_label12
+      y$adm_label <- y$adm_label12
     }
   } else if ((n0 > 1)) {
     if (agg == 0) {
@@ -107,10 +126,10 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
       y$adm_label <- y$adm_label012
     }
   }
-  
+
   y <- y %>% select(-c(adm_label_tmp, adm_label01, adm_label012, adm_label12))
   out <- list(df = y, agg = agg, ev = ev, epi = epi)
-  
+
   return(out)
 }
 
@@ -119,97 +138,110 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL) {
 # Plot core function (1 plot)
 
 plot_ev_ssn <- function(u, show_legend = T, ymax_val, ev_par, yrs, pcol, prow, epi_par = NULL, nth_plot = NULL) {
-  
   ev_val <- paste0("%{y:.2f} ", ev_par$unit)
   pmain <- unique(u$adm_label)
-  
+
   yrs <- sort(yrs)
   nyrs <- length(yrs)
   clr_yrs <- rev(rev(clr_seq)[1:nyrs])
-  
-  d0 <- min(u$date, na.rm = T) - 5; dF <- max(u$date, na.rm = T) + 5
-  
-  w <- ifelse(pcol<=3, 250, 300)
-  
+
+  d0 <- min(u$date, na.rm = T) - 5
+  dF <- max(u$date, na.rm = T) + 5
+
+  w <- ifelse(pcol <= 3, 250, 300)
+
   p <- plot_ly(data = u, height = 250 * prow, width = w * pcol) %>%
-    add_ribbons(ymin = ~ minval, ymax = ~ maxval, x = ~ date, line = list(color = clr_bar_grey), fillcolor = clr_bar_grey,
-                opacity = 0.2, name = "Historical data (2000 to 2021)", 
-                hovertemplate = "Historical Range (2000 to 2021)  <extra></extra>",
-                showlegend = F, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ minval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
-              name = "Historical minimum", hovertemplate = paste0("Hist. Min: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ monthly_ave, type = 'scatter', mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"), 
-              name = "Historical Average", hovertemplate = paste0("Hist. Ave: ", ev_val,"  <extra></extra>"), showlegend = show_legend, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ maxval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
-              name = "Historical maximum", hovertemplate = paste0("Hist. Max: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y")
-  
-  for(i in 1:nyrs) {
-    
-    yname <- paste0("clim_t",i)
+    add_ribbons(
+      ymin = ~minval, ymax = ~maxval, x = ~date, line = list(color = clr_bar_grey), fillcolor = clr_bar_grey,
+      opacity = 0.2, name = "Historical data (2000 to 2021)",
+      hovertemplate = "Historical Range (2000 to 2021)  <extra></extra>",
+      showlegend = F, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~minval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
+      name = "Historical minimum", hovertemplate = paste0("Hist. Min: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~monthly_ave, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"),
+      name = "Historical Average", hovertemplate = paste0("Hist. Ave: ", ev_val, "  <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~maxval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
+      name = "Historical maximum", hovertemplate = paste0("Hist. Max: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    )
+
+  for (i in 1:nyrs) {
+    yname <- paste0("clim_t", i)
     clri <- clr_yrs[i]
-    
-    dfi <- u %>% select(date, all_of(yname)) %>%
+
+    dfi <- u %>%
+      select(date, all_of(yname)) %>%
       rename(var_y = yname)
-    
+
     # if (i == 1) {
     #   hovtemp <- paste0("<b>", epi_par$label, "</b><br>", yrs[i], ": ", ev_val," <extra></extra>")
     # } else {
     #   hovtemp <- paste0(yrs[i], ": ", ev_val," <extra></extra>")
     # }
-    
-    p <- add_trace(p, x = ~ date, y = ~ var_y, data = dfi, type = "scatter", mode = "lines", 
-                   line = list(color = clri, width = 2),  name = as.character(yrs[i]), 
-                   hovertemplate = paste0(yrs[i], ": ", ev_val," <extra></extra>"), showlegend = show_legend, yaxis = "y")
+
+    p <- add_trace(p,
+      x = ~date, y = ~var_y, data = dfi, type = "scatter", mode = "lines",
+      line = list(color = clri, width = 2), name = as.character(yrs[i]),
+      hovertemplate = paste0(yrs[i], ": ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    )
   }
-  
-  
-  
-  if(!is.null(epi_par)) {
-    
+
+
+
+  if (!is.null(epi_par)) {
     clr_epi_yrs <- rev(rev(clr_epi_seq)[1:nyrs])
-    
-    if(epi_par$label == "TPR") {
+
+    if (epi_par$label == "TPR") {
       epi_val <- paste0("%{y:.2f} ", epi_par$unit)
     } else {
       epi_val <- paste0("%{y:d} ", epi_par$unit)
     }
-    
-   
-     for(i in 1:nyrs) {
-      
-      yname <- paste0("epi_t",i)
-      clri <- clr_epi_yrs[i]
-      
-      dei <- u %>% select(date, all_of(yname)) %>%
-        rename(var_y = yname)
-      
-      p <- add_trace(p, x = ~ date, y = ~ var_y, data = dei, type = "scatter", mode = "lines+markers", 
-                     line = list(color = clri, width = 2), marker = list(color = clri, size = 10), name = as.character(yrs[i]), 
-                     hovertemplate = paste0(yrs[i], ": ", epi_val," <extra></extra>"), showlegend = show_legend, yaxis = "y2") 
-     }
-    
-    tick2 <- pretty(epi_par$minaxs:epi_par$epi_max)
-    
-    tdf <- data.frame(xpos = max(u$date), ypos = tick2, text = label_number(scale_cut = cut_short_scale())(tick2))
-    
-    p <- add_trace(p, x = ~ xpos, y = ~ ypos, text = ~ text, type = "scatter", mode = "text",
-                   textposition = 'middle left', data = tdf, yaxis = "y2", 
-                   hovertemplate = "<span style='color:white'> </span><extra></extra>",
-                   textfont = list(size = 8))
 
-    
+
+    for (i in 1:nyrs) {
+      yname <- paste0("epi_t", i)
+      clri <- clr_epi_yrs[i]
+
+      dei <- u %>%
+        select(date, all_of(yname)) %>%
+        rename(var_y = yname)
+
+      p <- add_trace(p,
+        x = ~date, y = ~var_y, data = dei, type = "scatter", mode = "lines+markers",
+        line = list(color = clri, width = 2), marker = list(color = clri, size = 10), name = as.character(yrs[i]),
+        hovertemplate = paste0(yrs[i], ": ", epi_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y2"
+      )
+    }
+
+    tick2 <- pretty(epi_par$minaxs:epi_par$epi_max)
+
+    tdf <- data.frame(xpos = max(u$date), ypos = tick2, text = label_number(scale_cut = cut_short_scale())(tick2))
+
+    p <- add_trace(p,
+      x = ~xpos, y = ~ypos, text = ~text, type = "scatter", mode = "text",
+      textposition = "middle left", data = tdf, yaxis = "y2",
+      hovertemplate = "<span style='color:white'> </span><extra></extra>",
+      textfont = list(size = 8)
+    )
   }
-  
-  
+
+
   p <- p %>%
     layout(
-      autosize = F, 
-      annotations = list(text = paste0("<b>", pmain, "</b>"), 
-                         xref = "paper", yref = "paper",
-                         yanchor = "bottom", xanchor = "left",
-                         align = "center",
-                         x = 0.05, y = 0.98,
-                         font = list(size = 11), showarrow = F),
+      autosize = F,
+      annotations = list(
+        text = paste0("<b>", pmain, "</b>"),
+        xref = "paper", yref = "paper",
+        yanchor = "bottom", xanchor = "left",
+        align = "center",
+        x = 0.05, y = 0.98,
+        font = list(size = 11), showarrow = F
+      ),
       xaxis = list(
         title = "",
         tickangle = 0,
@@ -226,68 +258,69 @@ plot_ev_ssn <- function(u, show_legend = T, ymax_val, ev_par, yrs, pcol, prow, e
       yaxis = list(
         title = paste0(ev_par$label, " (", ev_par$unit, ")"),
         # margin = list(pad = 10),
-        range =  list(ev_par$minaxs, 1.05*ymax_val),
+        range = list(ev_par$minaxs, 1.05 * ymax_val),
         # position = t0+20,
         tickfont = list(size = 8)
       ),
       hovermode = "x unified", hoverdistance = 1
     )
-  
-  
-  if(!is.null(epi_par)) {
-    kaxs <- paste0("y", ifelse(nth_plot == 1, "", as.numeric((2* nth_plot) - 1)))
-    
+
+
+  if (!is.null(epi_par)) {
+    kaxs <- paste0("y", ifelse(nth_plot == 1, "", as.numeric((2 * nth_plot) - 1)))
+
     p <- p %>%
-      layout(yaxis2 = list(side = "right", overlaying = kaxs, range = list(0, 1.1*epi_par$epi_max), showgrid = F, 
-                           showticklabels = F))
+      layout(yaxis2 = list(
+        side = "right", overlaying = kaxs, range = list(0, 1.1 * epi_par$epi_max), showgrid = F,
+        showticklabels = F
+      ))
   }
-  
-  
+
+
   (p)
-  
 }
 
 
 
 # plot_ev_ssn <- function(u, show_legend = T, ymax_val, ev_par, yrs, pcol, prow) {
-#   
+#
 #   ev_val <- paste0("%{y:.2f} ", ev_par$unit)
 #   pmain <- unique(u$adm_label)
-#   
+#
 #   yrs <- sort(yrs)
 #   nyrs <- length(yrs)
 #   clr_yrs <- rev(rev(clr_seq)[1:nyrs])
-#   
+#
 #   w <- ifelse(pcol<=3, 250, 300)
-#   
+#
 #   p <- plot_ly(data = u, height = 250 * prow, width = w * pcol) %>%
 #     add_ribbons(ymin = ~ minval, ymax = ~ maxval, x = ~ date, line = list(color = clr_bar_grey), fillcolor = clr_bar_grey,
 #                 opacity = 0.2, name = "Historical data (2000 to 2021)", hoverinfo = "none", showlegend = F) %>%
 #     add_trace(x = ~ date, y = ~ minval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
 #               name = "Historical minimum", hovertemplate = paste0("Hist. Min: ", ev_val, " <extra></extra>"), showlegend = show_legend) %>%
-#     add_trace(x = ~ date, y = ~ monthly_ave, type = 'scatter', mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"), 
+#     add_trace(x = ~ date, y = ~ monthly_ave, type = 'scatter', mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"),
 #               name = "Historical Average", hovertemplate = paste0("Hist. Ave: ", ev_val,"  <extra></extra>"), showlegend = show_legend) %>%
 #     add_trace(x = ~ date, y = ~ maxval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
 #               name = "Historical maximum", hovertemplate = paste0("Hist. Max: ", ev_val, " <extra></extra>"), showlegend = show_legend)
-#   
+#
 #   for(i in 1:nyrs) {
-#     
+#
 #     yname <- paste0("clim_t",i)
 #     clri <- clr_yrs[i]
-#     
+#
 #     dfi <- u %>% select(date, all_of(yname)) %>%
 #       rename(var_y = yname)
-#     
-#     p <- add_trace(p, x = ~ date, y = ~ var_y, data = dfi, type = "scatter", mode = "lines", 
-#                    line = list(color = clri, width = 2),  name = as.character(yrs[i]), 
+#
+#     p <- add_trace(p, x = ~ date, y = ~ var_y, data = dfi, type = "scatter", mode = "lines",
+#                    line = list(color = clri, width = 2),  name = as.character(yrs[i]),
 #                 hovertemplate = paste0(yrs[i], ": ", ev_val," <extra></extra>"), showlegend = show_legend)
 #   }
-#   
-#   
+#
+#
 #   p <- p %>%
 #     layout(
-#       autosize = F, 
-#       annotations = list(text = paste0("<b>", pmain, "</b>"), 
+#       autosize = F,
+#       annotations = list(text = paste0("<b>", pmain, "</b>"),
 #                          xref = "paper", yref = "paper",
 #                          yanchor = "bottom", xanchor = "left",
 #                          align = "center",
@@ -312,21 +345,20 @@ plot_ev_ssn <- function(u, show_legend = T, ymax_val, ev_par, yrs, pcol, prow, e
 #       ),
 #       hovermode = "x unified"
 #     )
-#     
-#   
+#
+#
 #   (p)
-#     
+#
 # }
 
 
 get_ev_par <- function(ev) {
-  
   if (grepl("^rf", ev)) {
     y <- list(unit = "mm", label = "Rainfall", maxround = 25, minaxs = 0)
   } else if (grepl("lstd", ev)) {
-    y <- list(unit = '\u00B0C', label = "Land Surface Temp.", maxround = 5, minaxs = -12)
+    y <- list(unit = "\u00B0C", label = "Land Surface Temp.", maxround = 5, minaxs = -12)
   } else if (grepl("tair", ev)) {
-    y <- list(unit = '\u00B0C', label = "Air Temp.", maxround = 5, minaxs = 0)
+    y <- list(unit = "\u00B0C", label = "Air Temp.", maxround = 5, minaxs = 0)
   } else if (grepl("ndvi", ev)) {
     y <- list(unit = "unitless", label = "NDVI", maxround = 0.2, minaxs = -0.2)
   } else if (grepl("sh", ev)) {
@@ -336,16 +368,14 @@ get_ev_par <- function(ev) {
   } else {
     y <- list(unit = "unknown variable", label = "Unknown variable", maxround = 1, minaxs = 1)
   }
-  
+
   return(y)
-  
 }
 
 
 
 get_epi_par <- function(epi) {
-  
-  if(grepl("suspected", epi)) {
+  if (grepl("suspected", epi)) {
     y <- list(unit = ifelse(grepl("rate", epi), "cases/100K", "cases"), label = "Suspected Cases", maxround = 20, minaxs = 0)
   } else if (grepl("confirmed", epi)) {
     y <- list(unit = ifelse(grepl("rate", epi), "cases/100K", "cases"), label = "Confirmed Cases", maxround = 20, minaxs = 0)
@@ -360,40 +390,54 @@ get_epi_par <- function(epi) {
   } else {
     y <- list(unit = "unknown variable", label = "Unknown variable", maxround = 1, minaxs = 0)
   }
-  
+
   if (grepl("deaths", epi)) {
     y$label <- "Malaria Deaths per 1M"
-  } else if (grepl("rate", epi)){
+  } else if (grepl("rate", epi)) {
     y$label <- paste0(y$label, " per 100K")
   }
-  
+
   return(y)
-  
 }
 
 
 get_dummy <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn = "cy", yax_std = F, ssize = c(1200, 950)) {
-  
+
   # if(is.null(ev)) {ev = unique(xdf$variable_name)}
-  
+
   ev_par <- get_ev_par(ev = ev)
-  
+
   # Set the order of month for plotting + month labeling
   if (ssn == "cy") {
-    u$yr2use <- u$year; u$mo2use <- u$month; mo_label <- month.abb
-    u <- u %>% left_join(., mo_lookup %>% select(month, date_cy), by = "month") %>%
+    u$yr2use <- u$year
+    u$mo2use <- u$month
+    mo_label <- month.abb
+    u <- u %>%
+      left_join(., mo_lookup %>% select(month, date_cy), by = "month") %>%
       rename(date4pl = date_cy)
   } else {
-    u$yr2use <- u$yr_ssn; mo2use <- u$mo_ssn; mo_label <- month.abb[mo_lookup$month_ssn]
-    u <- u %>% left_join(., mo_lookup %>% select(month, date_ssn), by = "month") %>%
+    u$yr2use <- u$yr_ssn
+    mo2use <- u$mo_ssn
+    mo_label <- month.abb[mo_lookup$month_ssn]
+    u <- u %>%
+      left_join(., mo_lookup %>% select(month, date_ssn), by = "month") %>%
       rename(date4pl = date_ssn)
   }
-  
-  if (is.null(yrs)) { yrs <- unique(u$yr2use) }
-  
-  adm_grp <- switch(as.character(agg), '1' = 'admin_level_1', '2' = 'admin_level_2', '0' = 'country')
-  adm_grp <- u %>% select(geo_id, country, admin_level_1, admin_level_2) %>% distinct() %>%
-    arrange(country, admin_level_1, admin_level_2) %>% pull(geo_id)
+
+  if (is.null(yrs)) {
+    yrs <- unique(u$yr2use)
+  }
+
+  adm_grp <- switch(as.character(agg),
+    "1" = "admin_level_1",
+    "2" = "admin_level_2",
+    "0" = "country"
+  )
+  adm_grp <- u %>%
+    select(geo_id, country, admin_level_1, admin_level_2) %>%
+    distinct() %>%
+    arrange(country, admin_level_1, admin_level_2) %>%
+    pull(geo_id)
 
   tt <- data.frame(tid = 1:length(yrs), yr2use = sort(yrs))
 
@@ -402,12 +446,15 @@ get_dummy <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn = 
     select(geo_id, country, admin_level_1, admin_level_2, adm_label, aggregation_level, date, date4pl, month, yr2use, value, monthly_ave, minval, maxval, all_of(epi)) %>%
     left_join(., tt, by = "yr2use") %>%
     mutate(name = paste0("clim_t", tid)) %>%
-    pivot_wider(values_from = c(value, all_of(epi)), names_from = name,
-                id_cols = c(geo_id, country, admin_level_1, admin_level_2, adm_label, date4pl, month, monthly_ave, minval, maxval)) %>%
+    pivot_wider(
+      values_from = c(value, all_of(epi)), names_from = name,
+      id_cols = c(geo_id, country, admin_level_1, admin_level_2, adm_label, date4pl, month, monthly_ave, minval, maxval)
+    ) %>%
     rename(date = date4pl)
-  
-  if(!is.null(epi)) {
-    u1 <- u1 %>% rename_with(., ~ gsub("value\\_", "", .x)) %>%
+
+  if (!is.null(epi)) {
+    u1 <- u1 %>%
+      rename_with(., ~ gsub("value\\_", "", .x)) %>%
       rename_with(., ~ gsub(paste0(epi, "_clim"), "epi", .x))
   }
   return(u1)
@@ -415,114 +462,131 @@ get_dummy <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn = 
 
 
 get_plot_ssn <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn = "cy", yax_std = F, ssize = c(1200, 950), order = "alpha") {
-  
+
   # if(is.null(ev)) {ev = unique(xdf$variable_name)}
-  
+
   ev_par <- get_ev_par(ev = ev)
-  
+
   # Set the order of month for plotting + month labeling
   if (ssn == "cy") {
-    u$yr2use <- u$year; u$mo2use <- u$month; mo_label <- month.abb
-    u <- u %>% left_join(., mo_lookup %>% select(month, date_cy), by = "month") %>%
+    u$yr2use <- u$year
+    u$mo2use <- u$month
+    mo_label <- month.abb
+    u <- u %>%
+      left_join(., mo_lookup %>% select(month, date_cy), by = "month") %>%
       rename(date4pl = date_cy)
   } else {
-    u$yr2use <- u$yr_ssn; mo2use <- u$mo_ssn; mo_label <- month.abb[mo_lookup$month_ssn]
-    u <- u %>% left_join(., mo_lookup %>% select(month, date_ssn), by = "month") %>%
+    u$yr2use <- u$yr_ssn
+    mo2use <- u$mo_ssn
+    mo_label <- month.abb[mo_lookup$month_ssn]
+    u <- u %>%
+      left_join(., mo_lookup %>% select(month, date_ssn), by = "month") %>%
       rename(date4pl = date_ssn)
   }
-  
-  if (is.null(yrs)) { yrs <- unique(u$yr2use) }
-  
+
+  if (is.null(yrs)) {
+    yrs <- unique(u$yr2use)
+  }
+
   # adm_grp <- switch(as.character(agg), '1' = 'admin_level_1', '2' = 'admin_level_2', '0' = 'country')
-  adm_grp <- u %>% select(geo_id, country, admin_level_1, admin_level_2) %>% distinct() %>%
-    arrange(country, admin_level_1, admin_level_2) %>% pull(geo_id)
-  
+  adm_grp <- u %>%
+    select(geo_id, country, admin_level_1, admin_level_2) %>%
+    distinct() %>%
+    arrange(country, admin_level_1, admin_level_2) %>%
+    pull(geo_id)
+
   tt <- data.frame(tid = 1:length(yrs), yr2use = sort(yrs))
-  
+
   u1 <- u %>%
     filter(yr2use %in% tt$yr2use) %>%
     select(geo_id, country, admin_level_1, admin_level_2, adm_label, aggregation_level, date, date4pl, month, yr2use, value, monthly_ave, minval, maxval, all_of(epi)) %>%
     left_join(., tt, by = "yr2use") %>%
     mutate(name = paste0("clim_t", tid)) %>%
-    pivot_wider(values_from = c(value, all_of(epi)), names_from = name,
-                id_cols = c(geo_id, country, admin_level_1, admin_level_2, adm_label, date4pl, month, monthly_ave, minval, maxval)) %>%
+    pivot_wider(
+      values_from = c(value, all_of(epi)), names_from = name,
+      id_cols = c(geo_id, country, admin_level_1, admin_level_2, adm_label, date4pl, month, monthly_ave, minval, maxval)
+    ) %>%
     rename(date = date4pl)
-  
-  if(!is.null(epi)) {
-    u1 <- u1 %>% rename_with(., ~ gsub("value\\_", "", .x)) %>%
+
+  if (!is.null(epi)) {
+    u1 <- u1 %>%
+      rename_with(., ~ gsub("value\\_", "", .x)) %>%
       rename_with(., ~ gsub(paste0(epi, "_clim"), "epi", .x))
   }
-  
-  
+
+
   ugrp <- split(u1, u1$geo_id)
-  
-  
-  if(order == "alpha") {
-    alpha_order <- u1 %>% select(geo_id, country, admin_level_1, admin_level_2) %>%
-      distinct() %>% arrange(country, admin_level_1, admin_level_2)
-    
+
+
+  if (order == "alpha") {
+    alpha_order <- u1 %>%
+      select(geo_id, country, admin_level_1, admin_level_2) %>%
+      distinct() %>%
+      arrange(country, admin_level_1, admin_level_2)
+
     ugrp <- ugrp[c(as.character(alpha_order$geo_id))]
   } else {
-    
-    ll_order <- u1 %>% select(geo_id) %>% distinct() %>%
-      left_join(., ctrll) %>% arrange(lat)
+    ll_order <- u1 %>%
+      select(geo_id) %>%
+      distinct() %>%
+      left_join(., ctrll) %>%
+      arrange(lat)
     ugrp <- ugrp[rev(c(as.character(ll_order$geo_id)))]
-    
   }
-  
-  
-  
+
+
+
   ncols <- ifelse(ssize[1] < 980, 3, 5)
-  
-  nrows <- as.integer(ceiling((length(adm_grp))/ncols))
-    
-  
+
+  nrows <- as.integer(ceiling((length(adm_grp)) / ncols))
+
+
   pp <- list()
-  
+
   for (i in 1:length(ugrp)) {
-    
     uin <- ugrp[[i]] %>% arrange(date)
     show_legend <- ifelse(i == 1, TRUE, FALSE)
-    
+
     if (!is.null(epi)) {
       epi_par <- get_epi_par(epi)
       nth_plot <- i
     } else {
-      epi_par <-nth_plot <-  NULL
+      epi_par <- nth_plot <- NULL
     }
-    
-    
-    if(yax_std) {
-      ymax_val <- plyr::round_any(max(u1[, c("minval", "maxval", paste0("clim_t", 1:(nrow(tt))))], na.rm = TRUE), ev_par$maxround, f = ceiling) 
-      if(!is.null(epi)) {
-        epi_max <- plyr::round_any(max(u1[, c(paste0("epi_t", 1:(nrow(tt))))], na.rm = TRUE), epi_par$maxround, f = ceiling) 
+
+
+    if (yax_std) {
+      ymax_val <- plyr::round_any(max(u1[, c("minval", "maxval", paste0("clim_t", 1:(nrow(tt))))], na.rm = TRUE), ev_par$maxround, f = ceiling)
+      if (!is.null(epi)) {
+        epi_max <- plyr::round_any(max(u1[, c(paste0("epi_t", 1:(nrow(tt))))], na.rm = TRUE), epi_par$maxround, f = ceiling)
         epi_max <- ifelse(is.infinite(epi_max), 1, epi_max)
         epi_par$epi_max <- epi_max
       }
     } else {
-      ymax_val <- plyr::round_any(max(uin[, c("minval", "maxval", paste0("clim_t", 1:(nrow(tt))))], na.rm = TRUE), ev_par$maxround, f = ceiling) 
-      if(!is.null(epi)) {
-        epi_max <- plyr::round_any(max(uin[, c(paste0("epi_t", 1:(nrow(tt))))], na.rm = TRUE), epi_par$maxround, f = ceiling) 
+      ymax_val <- plyr::round_any(max(uin[, c("minval", "maxval", paste0("clim_t", 1:(nrow(tt))))], na.rm = TRUE), ev_par$maxround, f = ceiling)
+      if (!is.null(epi)) {
+        epi_max <- plyr::round_any(max(uin[, c(paste0("epi_t", 1:(nrow(tt))))], na.rm = TRUE), epi_par$maxround, f = ceiling)
         epi_max <- ifelse(is.infinite(epi_max), 1, epi_max)
         epi_par$epi_max <- epi_max
       }
     }
-    
-    
 
-    
-    pp[[i]] <- plot_ev_ssn(u = uin, show_legend = show_legend, ymax_val = ymax_val, ev_par = ev_par,  
-                           yrs = yrs, pcol = ncols, prow = nrows, epi_par = epi_par, nth_plot = nth_plot)
-    
+
+
+
+    pp[[i]] <- plot_ev_ssn(
+      u = uin, show_legend = show_legend, ymax_val = ymax_val, ev_par = ev_par,
+      yrs = yrs, pcol = ncols, prow = nrows, epi_par = epi_par, nth_plot = nth_plot
+    )
   }
-  
+
   ncols <- min(5, length(pp))
-  subplot(pp, nrows = nrows, #, margin = c(0.03, 0.03, 0.03, 0.03)#, 
-          widths = rep(signif(0.98/5, digits=3), times = ncols), 
-          heights = rep(signif(0.98/nrows, digits = 5), times = nrows)
-  ) %>% 
+  subplot(pp,
+    nrows = nrows, # , margin = c(0.03, 0.03, 0.03, 0.03)#,
+    widths = rep(signif(0.98 / 5, digits = 3), times = ncols),
+    heights = rep(signif(0.98 / nrows, digits = 5), times = nrows)
+  ) %>%
     layout(showlegend = F)
-  
 }
 
 
@@ -535,92 +599,106 @@ get_plot_ssn <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn
 
 
 plot_ev_histo <- function(u, show_legend = T, ymax_val, ev_par, pcol, prow, epi_par = NULL, nth_plot = NULL) {
-  
   ev_val <- paste0("%{y:.2f} ", ev_par$unit)
   pmain <- unique(u$adm_label)
-  
-  d0 <- min(u$date, na.rm = T) - 5; dF <- max(u$date, na.rm = T) + 5
-  
-  w <- ifelse(pcol<=2, 400, 400)
-  
+
+  d0 <- min(u$date, na.rm = T) - 5
+  dF <- max(u$date, na.rm = T) + 5
+
+  w <- ifelse(pcol <= 2, 400, 400)
+
   p <- plot_ly(data = u, height = 300 * prow, width = w * pcol) %>%
-    add_ribbons(ymin = ~ minval, ymax = ~ maxval, x = ~ date, line = list(color = clr_bar_grey), fillcolor = clr_bar_grey,
-                opacity = 0.2, name = "Historical data (2000 to 2021)", showlegend = F, yaxis = "y",
-                hovertemplate = "Historical Range (2000 to 2021)  <extra></extra>") %>%
-    add_trace(x = ~ date, y = ~ minval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
-              name = "Historical minimum", hovertemplate = paste0("Hist. Min: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ monthly_ave, type = 'scatter', mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"), 
-              name = "Historical Average", hovertemplate = paste0("Hist. Ave: ", ev_val,"  <extra></extra>"), showlegend = show_legend, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ maxval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
-              name = "Historical maximum", hovertemplate = paste0("Hist. Max: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y") %>%
-    add_trace(x = ~ date, y = ~ value, type = "scatter", mode = "lines", line = list(color = clr_red, width = 1),
-              name = "Current Month", hovertemplate = paste0("Current Month: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y") 
-  
-  if(!is.null(epi_par)) {
-    
+    add_ribbons(
+      ymin = ~minval, ymax = ~maxval, x = ~date, line = list(color = clr_bar_grey), fillcolor = clr_bar_grey,
+      opacity = 0.2, name = "Historical data (2000 to 2021)", showlegend = F, yaxis = "y",
+      hovertemplate = "Historical Range (2000 to 2021)  <extra></extra>"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~minval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
+      name = "Historical minimum", hovertemplate = paste0("Hist. Min: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~monthly_ave, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 2, dash = "dot"),
+      name = "Historical Average", hovertemplate = paste0("Hist. Ave: ", ev_val, "  <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~maxval, type = "scatter", mode = "lines", line = list(color = clr_bar_grey, width = 1),
+      name = "Historical maximum", hovertemplate = paste0("Hist. Max: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    ) %>%
+    add_trace(
+      x = ~date, y = ~value, type = "scatter", mode = "lines", line = list(color = clr_red, width = 1),
+      name = "Current Month", hovertemplate = paste0("Current Month: ", ev_val, " <extra></extra>"), showlegend = show_legend, yaxis = "y"
+    )
+
+  if (!is.null(epi_par)) {
     tick2 <- pretty(epi_par$minaxs:epi_par$epi_max)
-    
+
     tdf <- data.frame(xpos = max(u$date), ypos = tick2, text = label_number(scale_cut = cut_short_scale())(tick2))
-    
-    if(epi_par$label == "TPR") {
+
+    if (epi_par$label == "TPR") {
       epi_val <- paste0("%{y:.2f} ", epi_par$unit)
     } else {
       epi_val <- paste0("%{y:d} ", epi_par$unit)
     }
-    
-   
-    
-    p <- add_trace(p, x = ~ date, y = ~ value_epi, type = "scatter", mode = "lines+markers",
-                   line = list(color = clr_epi1, width = 1), marker = list(color = clr_epi1, size = 7),
-                   name = epi_par$label, hovertemplate = paste0(epi_par$label, ": ", epi_val, "<extra></extra>"),
-                   showlegend = show_legend, yaxis = "y2")
-    p <- add_trace(p, x = ~ xpos, y = ~ ypos, text = ~ text, type = "scatter", mode = "text",
-                textposition = 'middle left', data = tdf, yaxis = "y2", 
-                hovertemplate = "<span style='color:white'> </span><extra></extra>",
-                textfont = list(size = 8))
+
+
+
+    p <- add_trace(p,
+      x = ~date, y = ~value_epi, type = "scatter", mode = "lines+markers",
+      line = list(color = clr_epi1, width = 1), marker = list(color = clr_epi1, size = 7),
+      name = epi_par$label, hovertemplate = paste0(epi_par$label, ": ", epi_val, "<extra></extra>"),
+      showlegend = show_legend, yaxis = "y2"
+    )
+    p <- add_trace(p,
+      x = ~xpos, y = ~ypos, text = ~text, type = "scatter", mode = "text",
+      textposition = "middle left", data = tdf, yaxis = "y2",
+      hovertemplate = "<span style='color:white'> </span><extra></extra>",
+      textfont = list(size = 8)
+    )
   }
-  
-  
+
+
+  p <- p %>%
+    layout(
+      autosize = F,
+      annotations = list(
+        text = paste0("<b>", pmain, "</b>"),
+        xref = "paper", yref = "paper",
+        yanchor = "bottom", xanchor = "left",
+        align = "center",
+        x = 0.05, y = 0.98,
+        font = list(size = 10), showarrow = F
+      ),
+      xaxis = list(
+        title = "",
+        tickangle = 0,
+        dtick = "M6", tickformat = "%b<br>%Y",
+        ticks = "outside", ticklen = 4,
+        tickfont = list(size = 8),
+        showgrid = F,
+        range = c(d0, dF),
+        # margin = list(pad = -20),
+        hoverformat = "<b>%b-%Y<b>",
+        hoverlabel = list(font = list(weight = 800))
+      ),
+      yaxis = list(
+        title = paste0(ev_par$label, " (", ev_par$unit, ")"),
+        # margin = list(pad = 10),
+        range = list(ev_par$minaxs, 1.05 * ymax_val),
+        # position = t0,
+        tickfont = list(size = 8)
+      ),
+      hovermode = "x unified", hoverdistance = 1
+    )
+
+  if (!is.null(epi_par)) {
+    kaxs <- paste0("y", ifelse(nth_plot == 1, "", as.numeric((2 * nth_plot) - 1)))
     p <- p %>%
-      layout(
-        autosize = F, 
-        annotations = list(text = paste0("<b>", pmain, "</b>"), 
-                           xref = "paper", yref = "paper",
-                           yanchor = "bottom", xanchor = "left",
-                           align = "center",
-                           x = 0.05, y = 0.98,
-                           font = list(size = 10), showarrow = F),
-        xaxis = list(
-          title = "",
-          tickangle = 0,
-          dtick = "M6", tickformat = "%b<br>%Y",
-          ticks = "outside", ticklen = 4,
-          tickfont = list(size = 8),
-          showgrid = F,
-          range = c(d0, dF),
-          # margin = list(pad = -20),
-          hoverformat = "<b>%b-%Y<b>",
-          hoverlabel = list(font = list(weight = 800))
-        ),
-        yaxis = list(
-          title = paste0(ev_par$label, " (", ev_par$unit, ")"),
-          # margin = list(pad = 10),
-          range =  list(ev_par$minaxs, 1.05*ymax_val),
-          #position = t0,
-          tickfont = list(size = 8)
-        ),
-        hovermode = "x unified", hoverdistance = 1
-      )
-    
-    if(!is.null(epi_par)) {
-      kaxs <- paste0("y", ifelse(nth_plot == 1, "", as.numeric((2* nth_plot) - 1)))
-      p <- p %>%
-        layout( yaxis2 = list(side = "right", overlaying = kaxs, range = list(0, 1.1*epi_par$epi_max), showgrid = F, showticklabels = F) )
-    }
-  
+      layout(yaxis2 = list(side = "right", overlaying = kaxs, range = list(0, 1.1 * epi_par$epi_max), showgrid = F, showticklabels = F))
+  }
+
 
   (p)
-  
 }
 
 
@@ -628,47 +706,51 @@ plot_ev_histo <- function(u, show_legend = T, ymax_val, ev_par, pcol, prow, epi_
 ## > wrapper to plot historical --------------------------------------------------------------------
 
 get_plot_histo <- function(u, ev = NULL, epi = NULL, agg, date_range, ssn = "cy", yax_std = F, ssize = c(1200, 950)) {
-  
   ev_par <- get_ev_par(ev = ev)
-  
-  adm_grp <- u %>% select(geo_id, country, admin_level_1, admin_level_2) %>% distinct() %>%
-    arrange(country, admin_level_1, admin_level_2) %>% pull(geo_id)
-  
-  
+
+  adm_grp <- u %>%
+    select(geo_id, country, admin_level_1, admin_level_2) %>%
+    distinct() %>%
+    arrange(country, admin_level_1, admin_level_2) %>%
+    pull(geo_id)
+
+
   u1 <- u %>%
     select(geo_id, country, admin_level_1, admin_level_2, adm_label, aggregation_level, date, month, value, monthly_ave, minval, maxval, all_of(epi))
-  
-  
+
+
   if (!is.null(epi)) {
     u1 <- u1 %>% rename(value_epi = epi)
     epi_par <- get_epi_par(epi)
   } else {
     epi_par <- NULL
   }
-  
-  
+
+
   ugrp <- split(u1, u1$geo_id)
-  
-  alpha_order <- u1 %>% select(geo_id, country, admin_level_1, admin_level_2) %>%
-    distinct() %>% arrange(country, admin_level_1, admin_level_2)
-  
+
+  alpha_order <- u1 %>%
+    select(geo_id, country, admin_level_1, admin_level_2) %>%
+    distinct() %>%
+    arrange(country, admin_level_1, admin_level_2)
+
   ugrp <- ugrp[c(as.character(alpha_order$geo_id))]
-  
+
   ncols <- ifelse(ssize[1] < 980, 2, 4)
-  
-  nrows <- ceiling(length(adm_grp)/ncols)
-  
-  
+
+  nrows <- ceiling(length(adm_grp) / ncols)
+
+
   pp <- list()
-  
+
   nth_plot <- NULL
-  
+
   for (i in 1:length(ugrp)) {
     uin <- ugrp[[i]] %>% arrange(date)
     show_legend <- ifelse(i == 1, TRUE, FALSE)
-    
-    if(yax_std) {
-      ymax_val <- plyr::round_any(max(u1[, c("minval", "maxval", "value")], na.rm = TRUE), ev_par$maxround, f = ceiling) 
+
+    if (yax_std) {
+      ymax_val <- plyr::round_any(max(u1[, c("minval", "maxval", "value")], na.rm = TRUE), ev_par$maxround, f = ceiling)
       if (!is.null(epi)) {
         epi_max <- plyr::round_any(max(u1[, "value_epi"], na.rm = T), epi_par$maxround, f = ceiling)
         epi_max <- ifelse(is.infinite(epi_max), 1, epi_max)
@@ -676,7 +758,7 @@ get_plot_histo <- function(u, ev = NULL, epi = NULL, agg, date_range, ssn = "cy"
         nth_plot <- i
       }
     } else {
-      ymax_val <- plyr::round_any(max(uin[, c("minval", "maxval", "value")], na.rm = TRUE), ev_par$maxround, f = ceiling) 
+      ymax_val <- plyr::round_any(max(uin[, c("minval", "maxval", "value")], na.rm = TRUE), ev_par$maxround, f = ceiling)
       if (!is.null(epi)) {
         epi_max <- plyr::round_any(max(uin[, "value_epi"], na.rm = T), epi_par$maxround, f = ceiling)
         epi_max <- ifelse(is.infinite(epi_max), 1, epi_max)
@@ -684,17 +766,17 @@ get_plot_histo <- function(u, ev = NULL, epi = NULL, agg, date_range, ssn = "cy"
         nth_plot <- i
       }
     }
-    
-    pp[[i]] <- plot_ev_histo(u = uin, show_legend = show_legend, ymax_val = ymax_val, ev_par = ev_par, pcol = ncols, prow = nrows, 
-                             epi_par = epi_par, nth_plot = nth_plot)
-    
+
+    pp[[i]] <- plot_ev_histo(
+      u = uin, show_legend = show_legend, ymax_val = ymax_val, ev_par = ev_par, pcol = ncols, prow = nrows,
+      epi_par = epi_par, nth_plot = nth_plot
+    )
   }
-  
-  
-  subplot(pp, nrows = nrows, #, margin = c(0.03, 0.03, 0.03, 0.03)#, 
-          widths = rep(signif(0.98/ncols, digits=3), ncols), heights = rep(signif(0.98/nrows, digits = 5), nrows)
-  ) %>% 
+
+
+  subplot(pp,
+    nrows = nrows, # , margin = c(0.03, 0.03, 0.03, 0.03)#,
+    widths = rep(signif(0.98 / ncols, digits = 3), ncols), heights = rep(signif(0.98 / nrows, digits = 5), nrows)
+  ) %>%
     layout(showlegend = F)
-  
 }
-  

--- a/fun.R
+++ b/fun.R
@@ -80,7 +80,7 @@ get_choice_adm2 <- function(ctry_list, adm1_list) {
 # xu <- get_data_main(adm_res = "admin0", gid, gid1 = NULL, gid2 = NULL, ev = ev)
 
 
-get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
+get_data_main <- function(df, adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
   if (adm_res == "admin0") {
     gid <- gid0
     agg <- 0
@@ -103,14 +103,13 @@ get_data_main <- function(adm_res, gid0, gid1, gid2, ev, epi = NULL, userid) {
   # ) %>%
   #   mutate(date = as.Date(as.character(date)))
   
-  y <- df_all %>%
+  y <- df %>%
     filter(
       geo_id %in% gid,
       variable_name == ev,
       aggregation_level == agg
     )
-  y <- mdiver::user_level_filter_data(y, user =  userid)
-  
+
   n0 <- length(unique(y$country))
   n1 <- length(unique(y$admin_level_1))
   

--- a/fun.R
+++ b/fun.R
@@ -516,9 +516,10 @@ get_plot_ssn <- function(u, ev = NULL, epi = NULL, agg, yrs = c(2021, 2022), ssn
     
   }
   
-  
+  ncols <- min(5, length(pp))
   subplot(pp, nrows = nrows, #, margin = c(0.03, 0.03, 0.03, 0.03)#, 
-          widths = rep(signif(0.98/ncols, digits=3), ncols), heights = rep(signif(0.98/nrows, digits = 5), nrows)
+          widths = rep(signif(0.98/5, digits=3), times = ncols), 
+          heights = rep(signif(0.98/nrows, digits = 5), times = nrows)
   ) %>% 
     layout(showlegend = F)
   

--- a/fun.R
+++ b/fun.R
@@ -778,7 +778,7 @@ get_plot_histo <- function(u, ev = NULL, epi = NULL, agg, date_range, ssn = "cy"
     )
   }
 
-
+  ncols <- min(5, length(pp))
   subplot(pp,
     nrows = nrows, # , margin = c(0.03, 0.03, 0.03, 0.03)#,
     widths = rep(signif(0.98 / ncols, digits = 3), ncols), heights = rep(signif(0.98 / nrows, digits = 5), nrows)

--- a/global.R
+++ b/global.R
@@ -20,7 +20,8 @@ mo_lookup <- data.frame(month = 1:12, month_ssn = c(7:12, 1:6)) %>%
 
 date_now <- as.Date(paste0(format(Sys.Date(), "%Y-%m"), "-01"))
 
-ctrll <- read_civis('staging_pmihq.climate_app_ctrll')
+ctrll <- read_civis('staging_pmihq.climate_app_ctrll',
+                    database = "PMI")
    
 
 # Colors ---------------------------------------------------

--- a/global.R
+++ b/global.R
@@ -6,30 +6,39 @@ adm_master <- read_civis(232951469)
 
 
 adm0_choice <- adm_master %>%
-  filter(aggregation_level == 0) %>% select(geo_id, country) %>% arrange(country) %>%
-  relocate(country) %>% deframe()
+  filter(aggregation_level == 0) %>%
+  select(geo_id, country) %>%
+  arrange(country) %>%
+  relocate(country) %>%
+  deframe()
 
 ctry <- sort(unique(as.character(adm_master$country)))
 
 
 mo_lookup <- data.frame(month = 1:12, month_ssn = c(7:12, 1:6)) %>%
-  mutate(date_ssn = case_when(month %in% 7:12 ~ as.Date(paste0("2021-", month, "-01")),
-                              TRUE ~ as.Date(paste0("2022-", month, "-01"))),
-         date_cy = as.Date(paste0("2022-", month, "-01")))
+  mutate(
+    date_ssn = case_when(
+      month %in% 7:12 ~ as.Date(paste0("2021-", month, "-01")),
+      TRUE ~ as.Date(paste0("2022-", month, "-01"))
+    ),
+    date_cy = as.Date(paste0("2022-", month, "-01"))
+  )
 
 
 date_now <- as.Date(paste0(format(Sys.Date(), "%Y-%m"), "-01"))
 
-ctrll <- read_civis('staging_pmihq.climate_app_ctrll',
-                    database = "PMI")
-   
+ctrll <- read_civis(
+  x = "staging_pmihq.climate_app_ctrll",
+  database = "PMI"
+)
+
 
 # Colors ---------------------------------------------------
 
 clr_bar_grey <- "#cccccc"
-clr_red <-  "#cc3311"
+clr_red <- "#cc3311"
 clr_blue <- "#0077BB"
-clr_green <- "#4daf4a"   # "#EE7733"
+clr_green <- "#4daf4a" # "#EE7733"
 clr_grey <- "#BBBBBB"
 
 clr_seq <- c(clr_green, clr_blue, clr_red)
@@ -45,5 +54,3 @@ clr_epi_seq <- c(clr_epi3, clr_epi2, clr_epi1)
 # lgnd_epi_seq <- c("'container-circle green'", "'container-circle blue'", "'container-circle red'")
 
 lgnd_epi_seq <- c("linegreen-epi'", "'lineblue-epi'", "'linered-epi'")
-
-

--- a/global.R
+++ b/global.R
@@ -32,6 +32,12 @@ ctrll <- read_civis(
   database = "PMI"
 )
 
+# Import all Climate + QR data
+df_all <- read_civis(
+  x = "staging_pmihq.climate_app",
+  database = "PMI"
+) %>%
+  mutate(date = lubridate::ymd(date))
 
 # Colors ---------------------------------------------------
 

--- a/home.R
+++ b/home.R
@@ -1,13 +1,14 @@
-tab_home <- tabPanel (
-  "", icon = icon('house'), # icon = icon("home"),
-  tags$div (style = 'margin-left:5px;', # "margin-left:25px;",
-    fluidPage (
+tab_home <- tabPanel(
+  "",
+  icon = icon("house"), # icon = icon("home"),
+  tags$div(
+    style = "margin-left:5px;", # "margin-left:25px;",
+    fluidPage(
       fluidRow(
-        HTML("Welcome to CLIMATE dashboard! <br><br> 
+        HTML("Welcome to CLIMATE dashboard! <br><br>
              [Description of each plot (what questions they answer),
              how to use the dashboard, etc.")
       )
     )
   )
-  
 )

--- a/trackers.R
+++ b/trackers.R
@@ -1,163 +1,207 @@
 
-tab_trackers <- 
+tab_trackers <-
   tabPanel(
     "Trackers",
     useShinyjs(),
     includeCSS("www/style.css"),
-    
     tags$head(HTML("<script type='text/javascript' src='keep-alive.js'></script>")),
-    
+
     # Tabs
-    
+
     tags$head(tags$script('var dimension = [0, 0];$(document).on("shiny:connected", function(e) {
                                       dimension[0] = window.innerWidth; dimension[1] = window.innerHeight; Shiny.onInputChange("dimension", dimension);});
                                       $(window).resize(function(e) {dimension[0] = window.innerWidth; dimension[1] = window.innerHeight;
                                       Shiny.onInputChange("dimension", dimension); });')),
     fluidPage(
       fluidRow(
-        wellPanel(style = "padding-bottom: 4px; padding-top:4px;font-size:12px;",
-            fluidRow(
-              column(width = 6, HTML("<h5>FILTER</h5>")),
-              column(width = 6, align = "right", 
-                     actionButton(inputId = "goplot_track", label = "Update plots", 
-                        class = "btn-primary", style = "margin-top:10px;"))
-              
+        wellPanel(
+          style = "padding-bottom: 4px; padding-top:4px;font-size:12px;",
+          fluidRow(
+            column(width = 6, HTML("<h5>FILTER</h5>")),
+            column(
+              width = 6, align = "right",
+              actionButton(
+                inputId = "goplot_track", label = "Update plots",
+                class = "btn-primary", style = "margin-top:10px;"
+              )
+            )
+          ),
+          fluidRow(
+            style = "margin-top:4px; margin-bottom:0px;padding-bottom:0px; padding-top:0px;margin-bottom:0px;",
+            column(
+              width = 4, # style = "margin-top:-5px;",
+              selectizeInput(
+                inputId = "ev_track", label = HTML("Climate Variable"),
+                choices = c(
+                  "Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair",
+                  "Land Surface Temperature" = "lstd",
+                  "Vegetation Index" = "ndvi", "Specific Humidity" = "sh", "Soil Moisture" = "sm"
+                ),
+                selected = "rf"
+              )
             ),
-            fluidRow (style = "margin-top:4px; margin-bottom:0px;padding-bottom:0px; padding-top:0px;margin-bottom:0px;",
-                      column (width = 4, # style = "margin-top:-5px;",
-                              selectizeInput( 
-                                inputId = "ev_track", label = HTML("Climate Variable"),
-                                choices = c("Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair",
-                                            "Land Surface Temperature" = "lstd",
-                                            "Vegetation Index" = "ndvi", "Specific Humidity" = "sh", "Soil Moisture" = "sm"),
-                                selected = "rf"
-                              )),
-                      # column(6, actionButton(inputId = "goplot_track", label = "Update plots", class = "btn-primary",
-                      #                        style = "margin-top:18px;"))
-                      
-                      column(width = 4, 
-                             selectizeInput(
-                               inputId = "epi_track", label = HTML("Overlay Variable"), 
-                               choices = c("None" = "none", "Suspected Cases"  = "suspected_cases", 
-                                           "Suspected Cases per 100K" = "suspected_cases_rate",
-                                           "Tested Cases" = "tested_cases", "Tested Cases per 100K" = "tested_cases_rate",
-                                           "Confirmed Cases" = "confirmed_cases", "Confirmed Cases per 100K"= "confirmed_cases_rate",
-                                           "Test Positivity Rate (TPR)" = "tpr", 
-                                           "Severe Cases"= "severe_cases", "Severe Cases per 100K" = "severe_cases_rate",
-                                           "Malaria Deaths" = "malaria_deaths", "Malaria Deaths per 10K" = "malaria_deaths_rate"),
-                               selected = "none"
-                             )
-                      ),
-                      
-                      column (width = 4,
-                              selectizeInput (
-                                inputId = "gres_track", label = HTML("Geographical Aggregation"),
-                                choices = c("National (Country)" = "admin0", "Admin. Level 1" = "admin1", "Admin. Level 2" = "admin2"),
-                                selected = "admin0"
-                              ))
-            ),
-            fluidRow (style = "margin-top:0px; margin-bottom:1px;padding-bottom:1px;padding-top:0px;", 
-              
-              column (width = 4, style = "margin-top:-14px;",
-                      div(class = "smallbox",
-                        pickerInput(
-                          inputId = "adm0_track", label = HTML("Country"),
-                          choices = adm0_choice, selected = as.vector(adm0_choice),
-                          options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'), multiple = TRUE))),
+            # column(6, actionButton(inputId = "goplot_track", label = "Update plots", class = "btn-primary",
+            #                        style = "margin-top:18px;"))
 
-              column (width = 4,  style = "margin-top:-10px;",
-                div(class = "smallbox",
-                  pickerInput(
-                    inputId = "adm1_track", label = HTML("Admin. Level 1"),
-                    choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE))),
-              
-              column(width = 4,  style = "margin-top:-10px;",
-                 div(class = "smallbox",
-                   pickerInput(
-                     inputId = "adm2_track", label = HTML("Admin. Level 2"),
-                     choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
-                   )))
-              ) )),
+            column(
+              width = 4,
+              selectizeInput(
+                inputId = "epi_track", label = HTML("Overlay Variable"),
+                choices = c(
+                  "None" = "none", "Suspected Cases" = "suspected_cases",
+                  "Suspected Cases per 100K" = "suspected_cases_rate",
+                  "Tested Cases" = "tested_cases", "Tested Cases per 100K" = "tested_cases_rate",
+                  "Confirmed Cases" = "confirmed_cases", "Confirmed Cases per 100K" = "confirmed_cases_rate",
+                  "Test Positivity Rate (TPR)" = "tpr",
+                  "Severe Cases" = "severe_cases", "Severe Cases per 100K" = "severe_cases_rate",
+                  "Malaria Deaths" = "malaria_deaths", "Malaria Deaths per 10K" = "malaria_deaths_rate"
+                ),
+                selected = "none"
+              )
+            ),
+            column(
+              width = 4,
+              selectizeInput(
+                inputId = "gres_track", label = HTML("Geographical Aggregation"),
+                choices = c("National (Country)" = "admin0", "Admin. Level 1" = "admin1", "Admin. Level 2" = "admin2"),
+                selected = "admin0"
+              )
+            )
+          ),
+          fluidRow(
+            style = "margin-top:0px; margin-bottom:1px;padding-bottom:1px;padding-top:0px;",
+            column(
+              width = 4, style = "margin-top:-14px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm0_track", label = HTML("Country"),
+                  choices = adm0_choice, selected = as.vector(adm0_choice),
+                  options = list(`actions-box` = TRUE, `selectedTextFormat` = "count > 3"), multiple = TRUE
+                )
+              )
+            ),
+            column(
+              width = 4, style = "margin-top:-10px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm1_track", label = HTML("Admin. Level 1"),
+                  choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
+                )
+              )
+            ),
+            column(
+              width = 4, style = "margin-top:-10px;",
+              div(
+                class = "smallbox",
+                pickerInput(
+                  inputId = "adm2_track", label = HTML("Admin. Level 2"),
+                  choices = "None", selected = "None", options = list(`actions-box` = TRUE), multiple = TRUE
+                )
+              )
+            )
+          )
+        )
+      ),
       fluidRow(
         # fluidPage(
-        
+
         tabsetPanel(
-          tabPanel("Seasonality",
+          tabPanel(
+            "Seasonality",
             br(),
             HTML("<H4> Seasonality Tracker </H4>"),
             # HTML("text xtext txt"),
             # textOutput(outputId = "test_out"),
             # br(),
             br(),
-            
             fluidRow(
-              
-              column(width = 3, 
-                div(class = "smallbox",
-                     pickerInput(inputId = "year_ssn", label = HTML("<b>Year</b> (select up to 3)"),
-                                 choices = 2017:2022, selected = c(2022, 2021),
-                                 options = list(`max-options` = 3), multiple  = T))
+              column(
+                width = 3,
+                div(
+                  class = "smallbox",
+                  pickerInput(
+                    inputId = "year_ssn", label = HTML("<b>Year</b> (select up to 3)"),
+                    choices = 2017:2022, selected = c(2022, 2021),
+                    options = list(`max-options` = 3), multiple = T
+                  )
+                )
               ),
-              column(width = 3, 
-                div(class = "smallbox",
-                     radioGroupButtons(inputId = "yax_ssn", label = HTML("<b>Y-Axis Range</b>"), choices = c("Same", "Free"), 
-                                       justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))))),
-              column(width = 6, 
-                 div(class = "smallbox",
-                     radioGroupButtons(inputId = "sort_ssn", label = HTML("<b>Sort Plots</b>"), choices = c("Alphabetically", "By Latitude"), 
-                                       justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon")))))
-
-              
+              column(
+                width = 3,
+                div(
+                  class = "smallbox",
+                  radioGroupButtons(
+                    inputId = "yax_ssn", label = HTML("<b>Y-Axis Range</b>"), choices = c("Same", "Free"),
+                    justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))
+                  )
+                )
+              ),
+              column(
+                width = 6,
+                div(
+                  class = "smallbox",
+                  radioGroupButtons(
+                    inputId = "sort_ssn", label = HTML("<b>Sort Plots</b>"), choices = c("Alphabetically", "By Latitude"),
+                    justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))
+                  )
+                )
+              )
             ),
-            
-            fluidRow(style = 'margin-top:10px; margin-bottom:15px;',
-              column(width = 12, 
-                     htmlOutput(outputId = "legend_ssn")
-                     
-                     )
-              
+            fluidRow(
+              style = "margin-top:10px; margin-bottom:15px;",
+              column(
+                width = 12,
+                htmlOutput(outputId = "legend_ssn")
+              )
             ),
-            
-            
             withSpinner(plotlyOutput("myplot1_track"))
           ),
-          
-          
-          tabPanel("Historical",
-           HTML("<H4> Historical Tracker </H4>"),
-           # HTML("text xtext txt"),
-           # textOutput(outputId = "test_out2"),
-           # br(),
-           br(),
-           fluidRow(
-             column(width = 4, 
-                    airDatepickerInput(inputId = "date_histo", label = HTML("<b>Date Range</b>"), range = TRUE, 
-                                       view = "months", minView = "months", clearButton = T, update_on = "close",
-                                       dateFormat = "MMM yyyy", monthsField = "monthsShort", separator = " to ",
-                                       minDate = as.Date("2017-01-01"), maxDate = date_now, value = c(as.Date("2017-01-01"), date_now))
-             ),
-             column(width = 3, 
-                    radioGroupButtons(inputId = "yax_histo", label = HTML("<b>Y-Axis Range</b>"), choices = c("Same", "Free"), 
-                                      justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon")))),
-             column(width = 5, 
-                    radioGroupButtons(inputId = "sort_histo", label = HTML("<b>Sort Plots</b>"), choices = c("Alphabetically", "By Latitude"), 
-                                      justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))))
-             
-             
-           ),
-           
-           fluidRow(style = 'margin-top:10px; margin-bottom:15px;',
-                    column(width = 12, 
-                           htmlOutput(outputId = "legend_histo")
-                           
-                    )
-                    
-           ),
-           withSpinner(plotlyOutput("myplot2_track", width = "100%"))
+          tabPanel(
+            "Historical",
+            HTML("<H4> Historical Tracker </H4>"),
+            # HTML("text xtext txt"),
+            # textOutput(outputId = "test_out2"),
+            # br(),
+            br(),
+            fluidRow(
+              column(
+                width = 4,
+                airDatepickerInput(
+                  inputId = "date_histo", label = HTML("<b>Date Range</b>"), range = TRUE,
+                  view = "months", minView = "months", clearButton = T, update_on = "close",
+                  dateFormat = "MMM yyyy", monthsField = "monthsShort", separator = " to ",
+                  minDate = as.Date("2017-01-01"), maxDate = date_now, value = c(as.Date("2017-01-01"), date_now)
+                )
+              ),
+              column(
+                width = 3,
+                radioGroupButtons(
+                  inputId = "yax_histo", label = HTML("<b>Y-Axis Range</b>"), choices = c("Same", "Free"),
+                  justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))
+                )
+              ),
+              column(
+                width = 5,
+                radioGroupButtons(
+                  inputId = "sort_histo", label = HTML("<b>Sort Plots</b>"), choices = c("Alphabetically", "By Latitude"),
+                  justified = F, checkIcon = list(yes = icon("ok", lib = "glyphicon"))
+                )
+              )
+            ),
+            fluidRow(
+              style = "margin-top:10px; margin-bottom:15px;",
+              column(
+                width = 12,
+                htmlOutput(outputId = "legend_histo")
+              )
+            ),
+            withSpinner(plotlyOutput("myplot2_track", width = "100%"))
           )
         )
-        
-        
+
+
 
         # )
       )
@@ -171,27 +215,27 @@ tab_trackers <-
 
 
 # tab_trackers <- tabPanel ("Seasonal and Historical Trackers",
-#   
+#
 #   # Filter panel expanded ----------------------------------------------
-#   
+#
 #   fluidPage(
-#     
+#
 #     fluidRow(
 #         absolutePanel(
 #           id = "filter_track", height = "10%", width = "100%", left = "15px",
 #           style = "z-index: 100; background-color:#EEEEEE; padding: 15px;",
-#           
+#
 #           fluidRow(
 #             column (width = 2,
 #                     selectizeInput(
 #                       inputId = "ev_track", label = HTML("<b>Climate Variable</b>"),
-#                       choices = c("Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair", 
+#                       choices = c("Rainfall" = "rf", "Rainfall (cumulative)" = "rfacc", "Air Temperature" = "tair",
 #                                   "Land Surface Temperature" = "lstd",
 #                                   "Vegetation Index" = "ndvi", "Specific Humidity" = "sh", "Soil Moisture" = "sm"),
 #                       selected = "rf"
 #                     )
 #             ),
-#             
+#
 #             column (width = 2,
 #                     selectizeInput (
 #                       inputId = "gres_track", label = HTML("<b>Geographical Aggregation</b>"),
@@ -199,36 +243,36 @@ tab_trackers <-
 #                       selected = "admin0"
 #                     )
 #             ),
-#             
+#
 #             column (width = 3,
 #                     pickerInput(
 #                       inputId = "adm0_track", label = HTML("<b>Country</b>"),
 #                       choices = adm0_choice, selected = as.vector(adm0_choice),
 #                       options = list(`actions-box` = TRUE, `selectedTextFormat` = 'count > 3'), multiple = TRUE
 #                     )
-#             ), 
-#             
+#             ),
+#
 #             column(width = 4, uiOutput("adm1_track")),
 #             column(width = 4, uiOutput("adm2_track"))
-#             
+#
 #           ),
-#           
+#
 #           fluidRow(
 #             actionButton(inputId = "goplot_track", label = "Update plots", class = "btn-primary")
 #           )
-#           
+#
 #         )
-#       
+#
 #     ),
-#     
-#     
-#     
+#
+#
+#
 #     # Main Panel ----------------------------------------------
-#     
+#
 #     fluidRow(
-#       
+#
 #       ## > Plot panel--------------------------------------------
-#       
+#
 #       div (
 #         # fluidPage (
 #           column (id = "plot_panel_track",
@@ -255,7 +299,7 @@ tab_trackers <-
 #                       style = 'width: 1000px; overflow-x: scroll; height: 200px; overflow-y: scroll',
 #                       plotOutput("myplot2_track", height = "500px")
 #                     )
-#                     
+#
 #                   )
 #           )
 #         )
@@ -263,5 +307,5 @@ tab_trackers <-
 #       # end of plot panel & main panel
 #     )
 #   # )
-#   
+#
 # )

--- a/trackers.R
+++ b/trackers.R
@@ -57,6 +57,11 @@ tab_trackers <-
                   "Malaria Deaths" = "malaria_deaths", "Malaria Deaths per 10K" = "malaria_deaths_rate"
                 ),
                 selected = "none"
+              ),
+              shinyBS::bsTooltip(
+                id = "epi_track",
+                title = "Access Restricted by Country",
+                placement = "top"
               )
             ),
             column(


### PR DESCRIPTION
Summary of changes:
* Load climate + QR data in global.R and replace SQL queries with table filter operations
* Load `mdiver`, retrieve the countries that a user has access to using the `get_countries(userid, permissionset)` function, and set QR columns to NA for the countries a user is not permitted to access.
* Adds a hover-over tooltip to the epi variable drop-down menu to inform users that QR data will not be visible for countries they are not permitted to access.
* Fixes a bug in the subplots of the seasonal and historical trackers when fewer than 5 countries are selected.
* Applies the `tidyverse` style guide to all files, using the `styler` package.

Links to M-DIVE deployment:
* [Service](https://platform.civisanalytics.com/spa/#/services/4255)
* [Report](https://platform.civisanalytics.com/spa/#/reports/services/105731)
